### PR TITLE
feat: M1.4 Presidio detector wrapper

### DIFF
--- a/src/redactron/detect/presidio_detector.py
+++ b/src/redactron/detect/presidio_detector.py
@@ -1,0 +1,93 @@
+"""Presidio-based PII detector.
+
+Wraps Microsoft Presidio's AnalyzerEngine to detect PII entities in
+extracted text spans, then maps results back to PDF bounding boxes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+from presidio_analyzer import AnalyzerEngine, RecognizerResult
+
+from redactron.extract.text_layer import TextLayer
+
+# Default entities to detect when none are specified in the profile.
+DEFAULT_ENTITIES: list[str] = [
+    "PERSON",
+    "LOCATION",
+    "PHONE_NUMBER",
+    "EMAIL_ADDRESS",
+    "US_SSN",
+    "CREDIT_CARD",
+    "DATE_TIME",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Detection:
+    """A single PII detection mapped to a PDF page and bounding box."""
+
+    text: str
+    entity_type: str
+    score: float
+    page_num: int
+    bbox: tuple[float, float, float, float]  # x0, y0, x1, y1
+    preserve_last: int = field(default=0)  # for partial redaction
+
+
+@lru_cache(maxsize=1)
+def _get_engine() -> AnalyzerEngine:
+    """Return a cached AnalyzerEngine (expensive to initialise)."""
+    return AnalyzerEngine()
+
+
+def detect(
+    layers: list[TextLayer],
+    entities: list[str] | None = None,
+    score_threshold: float = 0.5,
+    language: str = "en",
+) -> list[Detection]:
+    """Detect PII entities in a list of TextLayer spans.
+
+    Each TextLayer is analysed independently; Presidio results are mapped
+    back to the layer's bounding box.
+
+    Args:
+        layers: Text spans extracted from a PDF page.
+        entities: Entity types to detect. Defaults to DEFAULT_ENTITIES.
+        score_threshold: Minimum confidence score to include a detection.
+        language: Language code for the Presidio analyser.
+
+    Returns:
+        List of Detection objects, one per recognised PII span.
+    """
+    if entities is None:
+        entities = DEFAULT_ENTITIES
+
+    engine = _get_engine()
+    detections: list[Detection] = []
+
+    for layer in layers:
+        if not layer.text:
+            continue
+
+        results: list[RecognizerResult] = engine.analyze(
+            text=layer.text,
+            entities=entities,
+            language=language,
+            score_threshold=score_threshold,
+        )
+
+        for result in results:
+            matched_text = layer.text[result.start : result.end]
+            detections.append(Detection(
+                text=matched_text,
+                entity_type=result.entity_type,
+                score=result.score,
+                page_num=layer.page_num,
+                bbox=layer.bbox,
+            ))
+
+    return detections

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,0 +1,99 @@
+"""Tests for src/redactron/detect/presidio_detector.py."""
+
+from redactron.detect.presidio_detector import DEFAULT_ENTITIES, Detection, detect
+from redactron.extract.text_layer import TextLayer
+
+
+def _layer(text: str, page: int = 0) -> TextLayer:
+    return TextLayer(page_num=page, text=text, bbox=(0.0, 0.0, 100.0, 12.0), block_type=0)
+
+
+def test_detect_returns_list() -> None:
+    layers = [_layer("Hello world")]
+    result = detect(layers)
+    assert isinstance(result, list)
+
+
+def test_detect_person() -> None:
+    layers = [_layer("My name is John Smith.")]
+    results = detect(layers, entities=["PERSON"])
+    assert any(d.entity_type == "PERSON" for d in results)
+
+
+def test_detect_email() -> None:
+    layers = [_layer("Contact me at john.smith@example.com")]
+    results = detect(layers, entities=["EMAIL_ADDRESS"])
+    assert any(d.entity_type == "EMAIL_ADDRESS" for d in results)
+
+
+def test_detect_phone() -> None:
+    layers = [_layer("Call +1-800-555-1234 for support.")]
+    results = detect(layers, entities=["PHONE_NUMBER"], score_threshold=0.4)
+    assert any(d.entity_type == "PHONE_NUMBER" for d in results)
+
+
+def test_detection_text_is_substring_of_layer() -> None:
+    layer = _layer("Email: alice@example.com")
+    results = detect([layer], entities=["EMAIL_ADDRESS"])
+    for d in results:
+        assert d.text in layer.text
+
+
+def test_detection_bbox_matches_layer() -> None:
+    layer = _layer("alice@example.com")
+    results = detect([layer], entities=["EMAIL_ADDRESS"])
+    assert len(results) > 0
+    assert results[0].bbox == layer.bbox
+
+
+def test_detection_page_num_preserved() -> None:
+    layer = _layer("john@example.com", page=3)
+    results = detect([layer], entities=["EMAIL_ADDRESS"])
+    assert len(results) > 0
+    assert results[0].page_num == 3
+
+
+def test_score_threshold_filters_low_confidence() -> None:
+    layers = [_layer("My name is John Smith.")]
+    high = detect(layers, entities=["PERSON"], score_threshold=0.9)
+    low = detect(layers, entities=["PERSON"], score_threshold=0.1)
+    assert len(low) >= len(high)
+
+
+def test_empty_layers_returns_empty() -> None:
+    assert detect([]) == []
+
+
+def test_empty_text_layer_skipped() -> None:
+    layers = [_layer("")]
+    result = detect(layers)
+    assert result == []
+
+
+def test_no_pii_returns_empty() -> None:
+    layers = [_layer("The quick brown fox jumps over the lazy dog.")]
+    results = detect(layers, entities=["US_SSN", "CREDIT_CARD"])
+    assert results == []
+
+
+def test_detection_is_frozen_dataclass() -> None:
+    d = Detection(
+        text="test", entity_type="PERSON", score=0.9,
+        page_num=0, bbox=(0.0, 0.0, 10.0, 10.0)
+    )
+    assert d.preserve_last == 0
+
+
+def test_default_entities_non_empty() -> None:
+    assert len(DEFAULT_ENTITIES) > 0
+
+
+def test_multipage_detections() -> None:
+    layers = [
+        _layer("john@example.com", page=0),
+        _layer("jane@example.com", page=2),
+    ]
+    results = detect(layers, entities=["EMAIL_ADDRESS"])
+    page_nums = {d.page_num for d in results}
+    assert 0 in page_nums
+    assert 2 in page_nums


### PR DESCRIPTION
## Summary

Adds `src/redactron/detect/presidio_detector.py`:

- `Detection` dataclass — `text`, `entity_type`, `score`, `page_num`, `bbox`, `preserve_last`
- `detect(layers, entities, score_threshold)` — pure function, `List[TextLayer] → List[Detection]`
- `AnalyzerEngine` cached via `lru_cache` (init is ~2s, amortised to zero after first call)
- Detects: PERSON, LOCATION, PHONE_NUMBER, EMAIL_ADDRESS, US_SSN, CREDIT_CARD, DATE_TIME

**Note:** Presidio scores phone numbers at ~0.4 for `+1-NXX` format; tests use `score_threshold=0.4` for that case.

## Verified

- `uv run ruff check src/ tests/` ✅
- `uv run mypy src/` ✅  
- `uv run pytest tests/test_detect.py` ✅ 14/14 — **100% coverage** on `presidio_detector.py`

Closes BLD-4