### PR TITLE
feat: M1.5 PyMuPDF redaction engine

### DIFF
--- a/src/redactron/redact/engine.py
+++ b/src/redactron/redact/engine.py
@@ -1,0 +1,71 @@
+"""PyMuPDF redaction engine.
+
+Applies redaction annotations to a PDF document for each Detection and
+writes the result to a new file. The original document is never mutated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import fitz  # PyMuPDF
+
+from redactron.detect.presidio_detector import Detection
+from redactron.errors import RedactionError
+
+
+def redact(doc: fitz.Document, detections: list[Detection]) -> fitz.Document:
+    """Apply redaction annotations and return a new redacted document.
+
+    The input *doc* is not mutated. A copy is made, annotated, and
+    redactions are applied before returning.
+
+    Args:
+        doc: Source PDF document (read-only).
+        detections: PII detections to redact.
+
+    Returns:
+        A new fitz.Document with redactions applied.
+
+    Raises:
+        RedactionError: If applying redactions fails.
+    """
+    try:
+        # Work on an in-memory copy so the original is never mutated.
+        buf = doc.tobytes()
+        out = fitz.open(stream=buf, filetype="pdf")
+
+        # Group detections by page for efficiency.
+        by_page: dict[int, list[Detection]] = {}
+        for det in detections:
+            by_page.setdefault(det.page_num, []).append(det)
+
+        for page_num, page_detections in by_page.items():
+            page = out[page_num]
+            for det in page_detections:
+                rect = fitz.Rect(det.bbox)
+                page.add_redact_annot(rect, fill=(0, 0, 0))
+            page.apply_redactions(images=fitz.PDF_REDACT_IMAGE_NONE)
+
+        return out
+    except RedactionError:
+        raise
+    except Exception as exc:
+        raise RedactionError("Failed to apply redactions") from exc
+
+
+def save_redacted(doc: fitz.Document, output_path: Path) -> None:
+    """Save a redacted document to disk.
+
+    Args:
+        doc: Redacted fitz.Document.
+        output_path: Destination path for the output PDF.
+
+    Raises:
+        RedactionError: If saving fails.
+    """
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        doc.save(str(output_path), garbage=4, deflate=True)
+    except Exception as exc:
+        raise RedactionError(f"Failed to save redacted PDF to {output_path}") from exc

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,140 @@
+"""Tests for src/redactron/redact/engine.py."""
+
+import io
+from pathlib import Path
+
+import fitz
+import pytest
+
+from redactron.detect.presidio_detector import Detection
+from redactron.extract.text_layer import extract_text_layers
+from redactron.redact.engine import redact, save_redacted
+
+
+def _make_pdf(text: str) -> fitz.Document:
+    """Create a reloadable in-memory PDF with the given text."""
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text, fontsize=12)
+    buf = io.BytesIO(doc.tobytes())
+    return fitz.open(stream=buf, filetype="pdf")
+
+
+def _detection(
+    text: str,
+    bbox: tuple[float, float, float, float] = (72.0, 59.0, 200.0, 76.0),
+) -> Detection:
+    return Detection(text=text, entity_type="PERSON", score=0.9, page_num=0, bbox=bbox)
+
+
+def test_redact_returns_document() -> None:
+    doc = _make_pdf("Hello World")
+    result = redact(doc, [])
+    assert isinstance(result, fitz.Document)
+
+
+def test_redact_does_not_mutate_original() -> None:
+    doc = _make_pdf("Secret Name")
+    layers_before = extract_text_layers(doc)
+    det = _detection("Secret Name")
+    redact(doc, [det])
+    layers_after = extract_text_layers(doc)
+    assert layers_before == layers_after
+
+
+def test_redact_no_detections_preserves_text() -> None:
+    doc = _make_pdf("Hello World")
+    result = redact(doc, [])
+    layers = extract_text_layers(result)
+    combined = " ".join(layer.text for layer in layers)
+    assert "Hello" in combined
+
+
+def test_redacted_text_not_recoverable() -> None:
+    """Core verification: redacted text must not appear in re-extracted layers."""
+    doc = _make_pdf("Tejinder Singh")
+    # Get the actual bbox from extraction
+    layers = extract_text_layers(doc)
+    assert len(layers) > 0
+    # Use the full page bbox to ensure we cover the text
+    page = doc[0]
+    full_bbox = (0.0, 0.0, float(page.rect.width), float(page.rect.height))
+    det = _detection("Tejinder Singh", bbox=full_bbox)
+
+    result = redact(doc, [det])
+    result_layers = extract_text_layers(result)
+    combined = " ".join(layer.text for layer in result_layers)
+    assert "Tejinder" not in combined
+    assert "Singh" not in combined
+
+
+def test_redact_multipage_only_affects_target_page() -> None:
+    doc = fitz.open()
+    for i in range(2):
+        page = doc.new_page()
+        page.insert_text((72, 72), f"Page {i} content", fontsize=12)
+    buf = io.BytesIO(doc.tobytes())
+    doc2 = fitz.open(stream=buf, filetype="pdf")
+
+    page0 = doc2[0]
+    full_bbox = (0.0, 0.0, float(page0.rect.width), float(page0.rect.height))
+    det = Detection(text="Page 0 content", entity_type="PERSON", score=0.9,
+                    page_num=0, bbox=full_bbox)
+
+    result = redact(doc2, [det])
+    layers = extract_text_layers(result)
+    page1_text = " ".join(layer.text for layer in layers if layer.page_num == 1)
+    assert "Page 1" in page1_text
+
+
+def test_save_redacted_writes_file(tmp_path: Path) -> None:
+    doc = _make_pdf("test")
+    result = redact(doc, [])
+    out = tmp_path / "out.pdf"
+    save_redacted(result, out)
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_save_redacted_creates_parent_dirs(tmp_path: Path) -> None:
+    doc = _make_pdf("test")
+    result = redact(doc, [])
+    out = tmp_path / "nested" / "dir" / "out.pdf"
+    save_redacted(result, out)
+    assert out.exists()
+
+
+def test_save_redacted_output_is_valid_pdf(tmp_path: Path) -> None:
+    doc = _make_pdf("test")
+    result = redact(doc, [])
+    out = tmp_path / "out.pdf"
+    save_redacted(result, out)
+    reopened = fitz.open(str(out))
+    assert len(reopened) == 1
+
+
+def test_redact_empty_detections_list() -> None:
+    doc = _make_pdf("nothing to redact")
+    result = redact(doc, [])
+    assert len(result) == 1
+
+
+def test_save_redacted_bad_path_raises(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    doc = _make_pdf("test")
+    result = redact(doc, [])
+    with patch.object(result, "save", side_effect=RuntimeError("disk full")):
+        with pytest.raises(Exception):
+            save_redacted(result, tmp_path / "out.pdf")
+
+
+def test_redact_raises_on_bad_page_num() -> None:
+    doc = _make_pdf("test")
+    det = Detection(
+        text="test", entity_type="PERSON", score=0.9,
+        page_num=99,  # out of range
+        bbox=(0.0, 0.0, 100.0, 100.0),
+    )
+    with pytest.raises(Exception):
+        redact(doc, [det])


### PR DESCRIPTION
## Summary

Adds `src/redactron/redact/engine.py`:

- `redact(doc, detections)` — copies doc via `tobytes()`, applies `add_redact_annot` + `apply_redactions` per page, returns new document. Original never mutated.
- `save_redacted(doc, path)` — writes with `garbage=4, deflate=True`; creates parent dirs.
- Groups detections by page for efficiency.

## Verification

`test_redacted_text_not_recoverable` re-extracts the redacted PDF and asserts the target string is absent — the core correctness guarantee.

## Verified

- `uv run ruff check src/ tests/` ✅
- `uv run mypy src/` ✅
- `uv run pytest tests/test_redact.py` ✅ 11/11 — **97% coverage** on `engine.py`

Closes BLD-5