### PR TITLE
feat: profile schema (Pydantic v2 + YAML loader)

### DIFF
--- a/src/redactron/profile.py
+++ b/src/redactron/profile.py
@@ -1,0 +1,128 @@
+"""Profile schema (Pydantic v2) and YAML loader for redactron.
+
+The profile.yaml file describes the subject's PII and detection settings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from redactron.errors import ProfileValidationError
+
+
+class AccountNumber(BaseModel):
+    """A single account number with optional last-N preservation."""
+
+    value: str
+    preserve_last: Annotated[int, Field(ge=1, le=16)] = 4
+
+
+class CustomPattern(BaseModel):
+    """A named regex pattern to redact."""
+
+    name: str
+    regex: str
+
+
+class Subject(BaseModel):
+    """PII belonging to the subject of redaction."""
+
+    display_name: str
+    aliases: list[str] = Field(default_factory=list)
+    addresses: list[str] = Field(default_factory=list)
+    phones: list[str] = Field(default_factory=list)
+    emails: list[str] = Field(default_factory=list)
+    ssns: list[str] = Field(default_factory=list)
+    account_numbers: list[AccountNumber] = Field(default_factory=list)
+    custom_patterns: list[CustomPattern] = Field(default_factory=list)
+
+    @field_validator("display_name")
+    @classmethod
+    def display_name_not_empty(cls, v: str) -> str:
+        """Ensure display_name is non-empty."""
+        if not v.strip():
+            raise ValueError("display_name must not be empty")
+        return v
+
+
+class DetectionConfig(BaseModel):
+    """Detection settings."""
+
+    use_presidio: bool = True
+    presidio_entities: list[str] = Field(
+        default_factory=lambda: [
+            "PERSON",
+            "LOCATION",
+            "PHONE_NUMBER",
+            "EMAIL_ADDRESS",
+            "US_SSN",
+            "CREDIT_CARD",
+            "DATE_TIME",
+        ]
+    )
+    fuzzy_match: bool = True
+    match_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.85
+    full_token_min_length: Annotated[int, Field(ge=1)] = 2
+    ocr_fallback: bool = False
+
+
+class Profile(BaseModel):
+    """Top-level profile schema."""
+
+    version: Annotated[int, Field(ge=1)] = 1
+    name: str = "default"
+    subject: Subject
+    detection: DetectionConfig = Field(default_factory=DetectionConfig)
+
+    @model_validator(mode="after")
+    def validate_version(self) -> Profile:
+        """Only version 1 is supported in v1."""
+        if self.version != 1:
+            raise ValueError(
+                f"Unsupported profile version: {self.version}. Only version 1 is supported."
+            )
+        return self
+
+
+def load_profile(path: Path) -> Profile:
+    """Load and validate a profile YAML file.
+
+    Args:
+        path: Path to the profile.yaml file.
+
+    Returns:
+        Validated Profile instance.
+
+    Raises:
+        ProfileValidationError: If the file is missing, invalid YAML, or fails schema validation.
+    """
+    if not path.exists():
+        raise ProfileValidationError(f"Profile not found: {path}")
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ProfileValidationError(f"Invalid YAML in {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ProfileValidationError(f"Profile must be a YAML mapping, got {type(raw).__name__}")
+    try:
+        return Profile.model_validate(raw)
+    except Exception as exc:
+        raise ProfileValidationError(f"Profile validation failed: {exc}") from exc
+
+
+def save_profile(profile: Profile, path: Path) -> None:
+    """Serialize a Profile to YAML and write it to disk.
+
+    Args:
+        profile: The Profile instance to save.
+        path: Destination path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(profile.model_dump(), default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,143 @@
+"""Tests for src/redactron/profile.py (BLD-7)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from redactron.errors import ProfileValidationError
+from redactron.profile import (
+    AccountNumber,
+    CustomPattern,
+    DetectionConfig,
+    Profile,
+    Subject,
+    load_profile,
+    save_profile,
+)
+
+SAMPLE_YAML = textwrap.dedent("""\
+    version: 1
+    name: default
+    subject:
+      display_name: "Tejinder Singh"
+      aliases: ["Tejinder", "T. Singh", "Singh, Tejinder"]
+      addresses:
+        - "100 Phillip Street, San Jose, CA 95020, USA"
+      phones: ["+1-408-555-1234"]
+      emails: ["tejinder.singh@ieee.org"]
+      ssns: ["xxx-xx-xxxx"]
+      account_numbers:
+        - value: "1234567890123456"
+          preserve_last: 4
+      custom_patterns:
+        - name: patient_id
+          regex: "PT-\\\\d{6}"
+    detection:
+      use_presidio: true
+      presidio_entities:
+        - PERSON
+        - LOCATION
+        - PHONE_NUMBER
+        - EMAIL_ADDRESS
+        - US_SSN
+        - CREDIT_CARD
+        - DATE_TIME
+      fuzzy_match: true
+      match_threshold: 0.85
+      full_token_min_length: 2
+      ocr_fallback: true
+""")
+
+
+def test_load_sample_profile(tmp_path: Path) -> None:
+    """Loads the sample profile from kickoff_prompt without errors."""
+    p = tmp_path / "profile.yaml"
+    p.write_text(SAMPLE_YAML)
+    profile = load_profile(p)
+    assert profile.version == 1
+    assert profile.subject.display_name == "Tejinder Singh"
+    assert len(profile.subject.aliases) == 3
+    assert profile.subject.account_numbers[0].preserve_last == 4
+    assert profile.detection.match_threshold == 0.85
+
+
+def test_load_minimal_profile(tmp_path: Path) -> None:
+    """Minimal profile with only required fields loads successfully."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("version: 1\nsubject:\n  display_name: Alice\n")
+    profile = load_profile(p)
+    assert profile.subject.display_name == "Alice"
+    assert profile.detection.use_presidio is True  # default
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    """Missing file raises ProfileValidationError."""
+    with pytest.raises(ProfileValidationError, match="not found"):
+        load_profile(tmp_path / "nonexistent.yaml")
+
+
+def test_invalid_yaml_raises(tmp_path: Path) -> None:
+    """Invalid YAML raises ProfileValidationError."""
+    p = tmp_path / "bad.yaml"
+    p.write_text("version: 1\nsubject: [unclosed")
+    with pytest.raises(ProfileValidationError, match="Invalid YAML"):
+        load_profile(p)
+
+
+def test_missing_display_name_raises(tmp_path: Path) -> None:
+    """Missing display_name raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("version: 1\nsubject:\n  aliases: []\n")
+    with pytest.raises(ProfileValidationError):
+        load_profile(p)
+
+
+def test_empty_display_name_raises(tmp_path: Path) -> None:
+    """Empty display_name raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text('version: 1\nsubject:\n  display_name: "  "\n')
+    with pytest.raises(ProfileValidationError, match="display_name"):
+        load_profile(p)
+
+
+def test_unsupported_version_raises(tmp_path: Path) -> None:
+    """Version != 1 raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("version: 2\nsubject:\n  display_name: Alice\n")
+    with pytest.raises(ProfileValidationError, match="version"):
+        load_profile(p)
+
+
+def test_invalid_threshold_raises() -> None:
+    """match_threshold outside [0,1] raises ValidationError."""
+    with pytest.raises(Exception):
+        DetectionConfig(match_threshold=1.5)
+
+
+def test_save_and_reload(tmp_path: Path) -> None:
+    """save_profile + load_profile round-trips correctly."""
+    profile = Profile(
+        subject=Subject(
+            display_name="Bob",
+            aliases=["Robert"],
+            account_numbers=[AccountNumber(value="9999888877776666", preserve_last=4)],
+            custom_patterns=[CustomPattern(name="emp_id", regex=r"EMP-\d{5}")],
+        )
+    )
+    path = tmp_path / "out.yaml"
+    save_profile(profile, path)
+    reloaded = load_profile(path)
+    assert reloaded.subject.display_name == "Bob"
+    assert reloaded.subject.aliases == ["Robert"]
+    assert reloaded.subject.account_numbers[0].value == "9999888877776666"
+
+
+def test_non_mapping_yaml_raises(tmp_path: Path) -> None:
+    """YAML that is not a mapping raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("- item1\n- item2\n")
+    with pytest.raises(ProfileValidationError, match="mapping"):
+        load_profile(p)


### PR DESCRIPTION
## Summary
Implements `src/redactron/profile.py` with full Pydantic v2 schema and YAML loader.

## Changes
- `Profile`, `Subject`, `AccountNumber`, `CustomPattern`, `DetectionConfig` models
- `load_profile(path)` / `save_profile(profile, path)`
- Raises `ProfileValidationError` on missing file, invalid YAML, or schema violations
- 10 unit tests, 100% coverage on profile.py

## Tested
`uv run pytest tests/test_profile.py` — 10/10 pass
`uv run ruff check` — clean
`uv run mypy src/redactron/profile.py` — clean

Closes BLD-7