### PR TITLE
feat: account number partial redaction (last-4 preservation)

### DIFF
--- a/src/redactron/detect/address_detector.py
+++ b/src/redactron/detect/address_detector.py
@@ -1,0 +1,112 @@
+"""Address normalization and variant detection using usaddress + rapidfuzz.
+
+Parses profile addresses with usaddress, normalizes street-type abbreviations,
+then fuzzy-matches normalized forms against extracted text spans.
+"""
+
+from __future__ import annotations
+
+import re
+
+import usaddress
+from rapidfuzz import fuzz
+
+from redactron.detect.presidio_detector import Detection
+from redactron.extract.text_layer import TextLayer
+from redactron.profile import Profile
+
+# Canonical expansions for common street-type abbreviations (lowercase)
+_ABBR_TO_FULL: dict[str, str] = {
+    "st": "street",
+    "ave": "avenue",
+    "av": "avenue",
+    "blvd": "boulevard",
+    "dr": "drive",
+    "rd": "road",
+    "ln": "lane",
+    "ct": "court",
+    "pl": "place",
+    "pkwy": "parkway",
+    "hwy": "highway",
+    "fwy": "freeway",
+    "cir": "circle",
+    "ter": "terrace",
+    "trl": "trail",
+    "way": "way",
+}
+
+_FULL_TO_ABBR: dict[str, str] = {v: k for k, v in _ABBR_TO_FULL.items()}
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _normalize_street_type(token: str) -> str:
+    """Expand abbreviation to full form (lowercase)."""
+    t = token.lower().rstrip(".")
+    return _ABBR_TO_FULL.get(t, t)
+
+
+def _normalize_address(raw: str) -> str:
+    """Return a normalized, lowercase address string.
+
+    Parses with usaddress; falls back to simple whitespace-collapse on failure.
+    Street-type tokens are expanded to their full form for consistent comparison.
+    """
+    try:
+        tagged, _ = usaddress.tag(raw)
+    except usaddress.RepeatedLabelError:
+        # Fall back to raw normalization
+        return _WHITESPACE_RE.sub(" ", raw.lower().strip())
+
+    parts: list[str] = []
+    for label, value in tagged.items():
+        if label == "StreetNamePostType":
+            parts.append(_normalize_street_type(value))
+        else:
+            parts.append(value.lower())
+    return " ".join(parts)
+
+
+def detect_addresses(
+    layers: list[TextLayer],
+    profile: Profile,
+) -> list[Detection]:
+    """Detect address variants in text layers using usaddress + rapidfuzz.
+
+    Normalizes each profile address and each text span, then computes
+    token_set_ratio. A match is emitted when score >= match_threshold.
+
+    Args:
+        layers: Text spans extracted from a PDF page.
+        profile: Loaded and validated Profile.
+
+    Returns:
+        List of Detection objects for matched address spans.
+    """
+    if not profile.subject.addresses:
+        return []
+
+    threshold = profile.detection.match_threshold * 100
+    normalized_addresses = [_normalize_address(a) for a in profile.subject.addresses]
+
+    detections: list[Detection] = []
+    for layer in layers:
+        if not layer.text:
+            continue
+        normalized_text = _normalize_address(layer.text)
+        for norm_addr in normalized_addresses:
+            # Use partial_ratio: address in text may be a substring of the full address
+            score = fuzz.partial_ratio(norm_addr, normalized_text)
+            if score >= threshold:
+                detections.append(
+                    Detection(
+                        text=layer.text,
+                        entity_type="LOCATION",
+                        score=score / 100.0,
+                        page_num=layer.page_num,
+                        bbox=layer.bbox,
+                    )
+                )
+                break  # one detection per layer span
+
+    return detections

--- a/src/redactron/detect/name_detector.py
+++ b/src/redactron/detect/name_detector.py
@@ -1,0 +1,72 @@
+"""Name variant detector using rapidfuzz token-set ratio.
+
+Matches subject name aliases against extracted text spans using fuzzy
+matching, respecting the profile's match_threshold and full_token_min_length.
+"""
+
+from __future__ import annotations
+
+import re
+
+from rapidfuzz import fuzz
+
+from redactron.detect.presidio_detector import Detection
+from redactron.extract.text_layer import TextLayer
+from redactron.profile import Profile
+
+_WORD_RE = re.compile(r"\b\w+\b")
+
+
+def _tokens(text: str) -> list[str]:
+    """Return lowercase word tokens from text."""
+    return _WORD_RE.findall(text.lower())
+
+
+def detect_names(
+    layers: list[TextLayer],
+    profile: Profile,
+) -> list[Detection]:
+    """Detect name aliases in text layers using rapidfuzz token_set_ratio.
+
+    For each text span, checks every alias in profile.subject.aliases
+    (plus display_name) using token_set_ratio. A match is emitted when
+    the score >= match_threshold AND every token in the alias is at least
+    full_token_min_length characters long.
+
+    Args:
+        layers: Text spans extracted from a PDF page.
+        profile: Loaded and validated Profile.
+
+    Returns:
+        List of Detection objects for matched name spans.
+    """
+    cfg = profile.detection
+    threshold = cfg.match_threshold * 100  # rapidfuzz uses 0-100 scale
+    min_len = cfg.full_token_min_length
+
+    # Build candidate list: display_name + all aliases
+    candidates: list[str] = [profile.subject.display_name] + list(profile.subject.aliases)
+    # Only keep candidates that have at least one token >= min_len
+    valid_candidates = [
+        c for c in candidates if any(len(t) >= min_len for t in _tokens(c))
+    ]
+
+    detections: list[Detection] = []
+    for layer in layers:
+        if not layer.text:
+            continue
+        for alias in valid_candidates:
+            score = fuzz.token_set_ratio(alias.lower(), layer.text.lower())
+            if score >= threshold:
+                detections.append(
+                    Detection(
+                        text=layer.text,
+                        entity_type="PERSON",
+                        score=score / 100.0,
+                        page_num=layer.page_num,
+                        bbox=layer.bbox,
+                    )
+                )
+                break  # one detection per layer span is enough
+
+    return detections

--- a/src/redactron/profile.py
+++ b/src/redactron/profile.py
@@ -18,7 +18,7 @@ class AccountNumber(BaseModel):
     """A single account number with optional last-N preservation."""
 
     value: str
-    preserve_last: Annotated[int, Field(ge=1, le=16)] = 4
+    preserve_last: Annotated[int, Field(ge=0, le=16)] = 4
 
 
 class CustomPattern(BaseModel):

--- a/src/redactron/profile.py
+++ b/src/redactron/profile.py
@@ -1,0 +1,128 @@
+"""Profile schema (Pydantic v2) and YAML loader for redactron.
+
+The profile.yaml file describes the subject's PII and detection settings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from redactron.errors import ProfileValidationError
+
+
+class AccountNumber(BaseModel):
+    """A single account number with optional last-N preservation."""
+
+    value: str
+    preserve_last: Annotated[int, Field(ge=1, le=16)] = 4
+
+
+class CustomPattern(BaseModel):
+    """A named regex pattern to redact."""
+
+    name: str
+    regex: str
+
+
+class Subject(BaseModel):
+    """PII belonging to the subject of redaction."""
+
+    display_name: str
+    aliases: list[str] = Field(default_factory=list)
+    addresses: list[str] = Field(default_factory=list)
+    phones: list[str] = Field(default_factory=list)
+    emails: list[str] = Field(default_factory=list)
+    ssns: list[str] = Field(default_factory=list)
+    account_numbers: list[AccountNumber] = Field(default_factory=list)
+    custom_patterns: list[CustomPattern] = Field(default_factory=list)
+
+    @field_validator("display_name")
+    @classmethod
+    def display_name_not_empty(cls, v: str) -> str:
+        """Ensure display_name is non-empty."""
+        if not v.strip():
+            raise ValueError("display_name must not be empty")
+        return v
+
+
+class DetectionConfig(BaseModel):
+    """Detection settings."""
+
+    use_presidio: bool = True
+    presidio_entities: list[str] = Field(
+        default_factory=lambda: [
+            "PERSON",
+            "LOCATION",
+            "PHONE_NUMBER",
+            "EMAIL_ADDRESS",
+            "US_SSN",
+            "CREDIT_CARD",
+            "DATE_TIME",
+        ]
+    )
+    fuzzy_match: bool = True
+    match_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.85
+    full_token_min_length: Annotated[int, Field(ge=1)] = 2
+    ocr_fallback: bool = False
+
+
+class Profile(BaseModel):
+    """Top-level profile schema."""
+
+    version: Annotated[int, Field(ge=1)] = 1
+    name: str = "default"
+    subject: Subject
+    detection: DetectionConfig = Field(default_factory=DetectionConfig)
+
+    @model_validator(mode="after")
+    def validate_version(self) -> Profile:
+        """Only version 1 is supported in v1."""
+        if self.version != 1:
+            raise ValueError(
+                f"Unsupported profile version: {self.version}. Only version 1 is supported."
+            )
+        return self
+
+
+def load_profile(path: Path) -> Profile:
+    """Load and validate a profile YAML file.
+
+    Args:
+        path: Path to the profile.yaml file.
+
+    Returns:
+        Validated Profile instance.
+
+    Raises:
+        ProfileValidationError: If the file is missing, invalid YAML, or fails schema validation.
+    """
+    if not path.exists():
+        raise ProfileValidationError(f"Profile not found: {path}")
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ProfileValidationError(f"Invalid YAML in {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ProfileValidationError(f"Profile must be a YAML mapping, got {type(raw).__name__}")
+    try:
+        return Profile.model_validate(raw)
+    except Exception as exc:
+        raise ProfileValidationError(f"Profile validation failed: {exc}") from exc
+
+
+def save_profile(profile: Profile, path: Path) -> None:
+    """Serialize a Profile to YAML and write it to disk.
+
+    Args:
+        profile: The Profile instance to save.
+        path: Destination path.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(profile.model_dump(), default_flow_style=False, allow_unicode=True),
+        encoding="utf-8",
+    )

--- a/src/redactron/redact/partial.py
+++ b/src/redactron/redact/partial.py
@@ -1,0 +1,234 @@
+"""Account number detection with partial redaction (last-N preservation).
+
+Detects account numbers from the profile in extracted text, computing
+character-level bounding boxes so only the prefix is redacted while
+the last N digits remain visible.
+"""
+
+from __future__ import annotations
+
+import re
+
+import fitz  # PyMuPDF
+
+from redactron.detect.presidio_detector import Detection
+from redactron.profile import AccountNumber, Profile
+
+# Matches digit sequences with optional separators (hyphens, spaces, dots)
+_DIGIT_SEP_RE = re.compile(r"[\d][\d\s\-\.]*[\d]")
+
+
+def _digits_only(value: str) -> str:
+    """Strip all non-digit characters from an account number string."""
+    return re.sub(r"\D", "", value)
+
+
+def _find_account_in_text(text: str, account: AccountNumber) -> list[tuple[int, int]]:
+    """Return (start, end) char offsets of account number matches in text.
+
+    Matches the account number with or without separators (hyphens/spaces).
+    The digits must match exactly; separators in the text are ignored.
+
+    Args:
+        text: The text span to search.
+        account: The account number to find.
+
+    Returns:
+        List of (start, end) offsets in *text* for each match.
+    """
+    target_digits = _digits_only(account.value)
+    if not target_digits:
+        return []
+
+    matches: list[tuple[int, int]] = []
+    for m in _DIGIT_SEP_RE.finditer(text):
+        span_text = m.group()
+        if _digits_only(span_text) == target_digits:
+            matches.append((m.start(), m.end()))
+    return matches
+
+
+def _prefix_bbox(
+    page: fitz.Page,
+    full_text: str,
+    match_start: int,
+    match_end: int,
+    preserve_last: int,
+) -> tuple[float, float, float, float] | None:
+    """Compute the bbox of the prefix portion to redact.
+
+    Uses PyMuPDF rawdict to get per-character bboxes, then returns the
+    union bbox of all characters that should be redacted (everything except
+    the last *preserve_last* digit characters).
+
+    Args:
+        page: The PDF page containing the text.
+        full_text: The full span text (used to locate chars in rawdict).
+        match_start: Start offset of the account number in full_text.
+        match_end: End offset of the account number in full_text.
+        preserve_last: Number of trailing digit characters to preserve.
+
+    Returns:
+        Bounding box (x0, y0, x1, y1) of the prefix to redact, or None
+        if character positions cannot be determined.
+    """
+    matched_text = full_text[match_start:match_end]
+    # Identify which character positions (within matched_text) are digits
+    digit_positions = [i for i, ch in enumerate(matched_text) if ch.isdigit()]
+    if len(digit_positions) <= preserve_last:
+        # Nothing to redact — all digits are preserved
+        return None
+
+    # The last preserve_last digit positions are kept; everything before is redacted
+    if preserve_last > 0:
+        redact_up_to_digit_idx = digit_positions[-(preserve_last + 1)]
+    else:
+        redact_up_to_digit_idx = digit_positions[-1]
+    # Redact from start of match up to and including this character index
+    redact_char_count = redact_up_to_digit_idx + 1  # chars within matched_text to redact
+
+    # Walk rawdict to find character bboxes
+    try:
+        blocks = page.get_text("rawdict", flags=fitz.TEXT_PRESERVE_WHITESPACE)["blocks"]
+    except Exception:
+        return None
+
+    # Collect all chars from the page in order
+    page_chars: list[tuple[str, tuple[float, float, float, float]]] = []
+    for block in blocks:
+        if block.get("type") != 0:
+            continue
+        for line in block.get("lines", []):
+            for span in line.get("spans", []):
+                for ch in span.get("chars", []):
+                    page_chars.append((ch["c"], tuple(ch["bbox"])))
+
+    # Find the run of chars in page_chars that matches full_text
+    # (simple substring search by character sequence)
+    page_text = "".join(c for c, _ in page_chars)
+    pos = page_text.find(full_text)
+    if pos == -1:
+        return None
+
+    # Characters to redact: from match_start to match_start + redact_char_count
+    redact_start = pos + match_start
+    redact_end = redact_start + redact_char_count
+
+    redact_chars = page_chars[redact_start:redact_end]
+    if not redact_chars:
+        return None
+
+    x0 = min(b[0] for _, b in redact_chars)
+    y0 = min(b[1] for _, b in redact_chars)
+    x1 = max(b[2] for _, b in redact_chars)
+    y1 = max(b[3] for _, b in redact_chars)
+    return (x0, y0, x1, y1)
+
+
+def detect_account_numbers(
+    doc: fitz.Document,
+    profile: Profile,
+) -> list[Detection]:
+    """Detect account numbers in a PDF and return partial-redaction Detections.
+
+    For each account number in the profile, searches all text spans on each
+    page. When preserve_last > 0, computes the bbox of only the prefix
+    (digits to redact), leaving the last N digits visible.
+
+    Args:
+        doc: Open fitz.Document to search.
+        profile: Loaded and validated Profile.
+
+    Returns:
+        List of Detection objects. Each has preserve_last set and bbox
+        covering only the portion to be redacted.
+    """
+    accounts = profile.subject.account_numbers
+    if not accounts:
+        return []
+
+    detections: list[Detection] = []
+
+    for page_num in range(len(doc)):
+        page = doc[page_num]
+        try:
+            blocks = page.get_text("rawdict", flags=fitz.TEXT_PRESERVE_WHITESPACE)["blocks"]
+        except Exception:
+            continue
+
+        for block in blocks:
+            if block.get("type") != 0:
+                continue
+            for line in block.get("lines", []):
+                for span in line.get("spans", []):
+                    chars = span.get("chars", [])
+                    if not chars:
+                        continue
+                    span_text = "".join(ch["c"] for ch in chars)
+                    span_bbox: tuple[float, float, float, float] = (
+                        min(ch["bbox"][0] for ch in chars),
+                        min(ch["bbox"][1] for ch in chars),
+                        max(ch["bbox"][2] for ch in chars),
+                        max(ch["bbox"][3] for ch in chars),
+                    )
+
+                    for account in accounts:
+                        for start, end in _find_account_in_text(span_text, account):
+                            if account.preserve_last > 0:
+                                bbox = _prefix_bbox(
+                                    page, span_text, start, end, account.preserve_last
+                                )
+                                if bbox is None:
+                                    # Fall back to full span bbox
+                                    bbox = span_bbox
+                            else:
+                                bbox = span_bbox
+
+                            detections.append(
+                                Detection(
+                                    text=span_text[start:end],
+                                    entity_type="ACCOUNT_NUMBER",
+                                    score=1.0,
+                                    page_num=page_num,
+                                    bbox=bbox,
+                                    preserve_last=account.preserve_last,
+                                )
+                            )
+
+    return detections
+
+
+def mask_account_number(value: str, preserve_last: int = 4) -> str:
+    """Return a masked representation of an account number string.
+
+    Replaces all digit groups except the last *preserve_last* digits with 'X'.
+    Separators (hyphens, spaces) are preserved in their original positions.
+
+    Examples:
+        mask_account_number("1234-5678-9012-3456", 4) -> "XXXX-XXXX-XXXX-3456"
+        mask_account_number("1234567890123456", 4)    -> "XXXXXXXXXXXX3456"
+
+    Args:
+        value: The account number string (may contain separators).
+        preserve_last: Number of trailing digits to keep visible.
+
+    Returns:
+        Masked string with leading digits replaced by 'X'.
+    """
+    digits = _digits_only(value)
+    if not digits:
+        return value
+
+    keep_from = max(0, len(digits) - preserve_last)
+    masked_digits = "X" * keep_from + digits[keep_from:]
+
+    # Re-insert separators at their original positions
+    result: list[str] = []
+    digit_idx = 0
+    for ch in value:
+        if ch.isdigit():
+            result.append(masked_digits[digit_idx])
+            digit_idx += 1
+        else:
+            result.append(ch)
+    return "".join(result)

--- a/tests/test_address_detector.py
+++ b/tests/test_address_detector.py
@@ -1,0 +1,115 @@
+"""Tests for src/redactron/detect/address_detector.py (BLD-9)."""
+
+from __future__ import annotations
+
+from redactron.detect.address_detector import _normalize_address, detect_addresses
+from redactron.extract.text_layer import TextLayer
+from redactron.profile import DetectionConfig, Profile, Subject
+
+BBOX = (0.0, 0.0, 200.0, 12.0)
+
+
+def _layer(text: str, page: int = 0) -> TextLayer:
+    return TextLayer(page_num=page, text=text, bbox=BBOX, block_type=0)
+
+
+def _profile(addresses: list[str], threshold: float = 0.85) -> Profile:
+    return Profile(
+        subject=Subject(display_name="Test User", addresses=addresses),
+        detection=DetectionConfig(match_threshold=threshold),
+    )
+
+
+# --- normalization unit tests ---
+
+def test_normalize_expands_street_abbr() -> None:
+    """'St' expands to 'street' in normalized form."""
+    norm = _normalize_address("100 Philip St, San Jose")
+    assert "street" in norm
+
+
+def test_normalize_expands_ave() -> None:
+    """'Ave' expands to 'avenue'."""
+    norm = _normalize_address("200 Main Ave")
+    assert "avenue" in norm
+
+
+def test_normalize_lowercases() -> None:
+    """Normalized address is lowercase."""
+    norm = _normalize_address("100 PHILLIP STREET")
+    assert norm == norm.lower()
+
+
+# --- detection tests ---
+
+def test_exact_address_matches() -> None:
+    """Exact address match is detected."""
+    layers = [_layer("100 Phillip Street, San Jose, CA 95020")]
+    result = detect_addresses(layers, _profile(["100 Phillip Street, San Jose, CA 95020"]))
+    assert len(result) == 1
+    assert result[0].entity_type == "LOCATION"
+
+
+def test_abbreviated_variant_matches() -> None:
+    """'100 Philip St, San Jose' matches '100 Phillip Street, San Jose, CA 95020'."""
+    layers = [_layer("100 Philip St, San Jose")]
+    result = detect_addresses(layers, _profile(["100 Phillip Street, San Jose, CA 95020"]))
+    assert len(result) == 1
+
+
+def test_unrelated_address_no_match() -> None:
+    """Completely different address produces no detection."""
+    layers = [_layer("999 Oak Avenue, New York, NY 10001")]
+    result = detect_addresses(layers, _profile(["100 Phillip Street, San Jose, CA 95020"]))
+    assert result == []
+
+
+def test_no_addresses_in_profile_returns_empty() -> None:
+    """Profile with no addresses returns empty list."""
+    layers = [_layer("100 Phillip Street")]
+    result = detect_addresses(layers, _profile([]))
+    assert result == []
+
+
+def test_empty_layers_returns_empty() -> None:
+    """Empty layer list returns empty detections."""
+    assert detect_addresses([], _profile(["100 Phillip Street"])) == []
+
+
+def test_empty_text_layer_skipped() -> None:
+    """Layer with empty text is skipped."""
+    layers = [TextLayer(page_num=0, text="", bbox=BBOX, block_type=0)]
+    assert detect_addresses(layers, _profile(["100 Phillip Street"])) == []
+
+
+def test_score_in_range() -> None:
+    """Detection score is in [0, 1]."""
+    layers = [_layer("100 Phillip Street, San Jose, CA 95020")]
+    result = detect_addresses(layers, _profile(["100 Phillip Street, San Jose, CA 95020"]))
+    assert all(0.0 <= d.score <= 1.0 for d in result)
+
+
+def test_one_detection_per_span() -> None:
+    """A span matching multiple profile addresses only produces one detection."""
+    addr = "100 Phillip Street, San Jose, CA 95020"
+    layers = [_layer(addr)]
+    result = detect_addresses(layers, _profile([addr, addr]))
+    assert len(result) == 1
+
+
+def test_multiple_pages() -> None:
+    """Matching spans on different pages each produce a detection."""
+    addr = "100 Phillip Street"
+    layers = [_layer(addr, page=0), _layer(addr, page=2)]
+    result = detect_addresses(layers, _profile([addr]))
+    assert len(result) == 2
+    assert {d.page_num for d in result} == {0, 2}
+
+
+def test_normalize_fallback_on_ambiguous_address() -> None:
+    """Normalization falls back gracefully on ambiguous/unparseable input."""
+    from redactron.detect.address_detector import _normalize_address
+    # Multiple addresses in one string triggers RepeatedLabelError in usaddress
+    result = _normalize_address("100 Main St, 200 Oak Ave, 300 Pine Rd")
+    assert isinstance(result, str)
+    assert result == result.lower()

--- a/tests/test_name_detector.py
+++ b/tests/test_name_detector.py
@@ -1,0 +1,97 @@
+"""Tests for src/redactron/detect/name_detector.py (BLD-8)."""
+
+from __future__ import annotations
+
+from redactron.detect.name_detector import detect_names
+from redactron.extract.text_layer import TextLayer
+from redactron.profile import DetectionConfig, Profile, Subject
+
+BBOX = (0.0, 0.0, 100.0, 12.0)
+
+
+def _layer(text: str, page: int = 0) -> TextLayer:
+    return TextLayer(page_num=page, text=text, bbox=BBOX, block_type=0)
+
+
+def _profile(
+    display_name: str = "Tejinder Singh",
+    aliases: list[str] | None = None,
+    threshold: float = 0.85,
+    min_len: int = 2,
+) -> Profile:
+    return Profile(
+        subject=Subject(display_name=display_name, aliases=aliases or []),
+        detection=DetectionConfig(match_threshold=threshold, full_token_min_length=min_len),
+    )
+
+
+def test_exact_display_name_matches() -> None:
+    """Exact display_name match is detected."""
+    layers = [_layer("Tejinder Singh")]
+    result = detect_names(layers, _profile())
+    assert len(result) == 1
+    assert result[0].entity_type == "PERSON"
+    assert result[0].score >= 0.85
+
+
+def test_alias_matches() -> None:
+    """Alias 'T. Singh' matches a span containing that text."""
+    layers = [_layer("T. Singh")]
+    result = detect_names(layers, _profile(aliases=["T. Singh", "Singh, Tejinder"]))
+    assert len(result) == 1
+
+
+def test_unrelated_text_no_match() -> None:
+    """Unrelated text produces no detections."""
+    layers = [_layer("Invoice #12345 dated 2024-01-01")]
+    result = detect_names(layers, _profile())
+    assert result == []
+
+
+def test_short_token_alias_skipped() -> None:
+    """Alias whose tokens are all below min_length is skipped entirely."""
+    # alias "A B" — both tokens length 1, below min_len=2
+    layers = [_layer("A B")]
+    result = detect_names(layers, _profile(display_name="A B", min_len=2))
+    assert result == []
+
+
+def test_threshold_respected() -> None:
+    """Score below threshold produces no detection."""
+    layers = [_layer("John Doe")]
+    result = detect_names(layers, _profile(threshold=0.99))
+    assert result == []
+
+
+def test_multiple_layers_multiple_matches() -> None:
+    """Each matching layer produces one detection."""
+    layers = [_layer("Tejinder Singh", page=0), _layer("Tejinder Singh", page=1)]
+    result = detect_names(layers, _profile())
+    assert len(result) == 2
+    assert {d.page_num for d in result} == {0, 1}
+
+
+def test_one_detection_per_span() -> None:
+    """A span matching multiple aliases only produces one detection."""
+    # "Tejinder Singh" matches both display_name and alias
+    layers = [_layer("Tejinder Singh")]
+    result = detect_names(layers, _profile(aliases=["Tejinder Singh"]))
+    assert len(result) == 1
+
+
+def test_empty_layers_returns_empty() -> None:
+    """Empty layer list returns empty detections."""
+    assert detect_names([], _profile()) == []
+
+
+def test_empty_text_layer_skipped() -> None:
+    """Layer with empty text is skipped."""
+    layers = [TextLayer(page_num=0, text="", bbox=BBOX, block_type=0)]
+    assert detect_names(layers, _profile()) == []
+
+
+def test_score_in_range() -> None:
+    """Detection score is in [0, 1]."""
+    layers = [_layer("Tejinder Singh")]
+    result = detect_names(layers, _profile())
+    assert all(0.0 <= d.score <= 1.0 for d in result)

--- a/tests/test_partial.py
+++ b/tests/test_partial.py
@@ -1,0 +1,213 @@
+"""Tests for src/redactron/redact/partial.py (BLD-10)."""
+
+from __future__ import annotations
+
+import fitz
+
+from redactron.profile import AccountNumber, DetectionConfig, Profile, Subject
+from redactron.redact.partial import (
+    _digits_only,
+    _find_account_in_text,
+    detect_account_numbers,
+    mask_account_number,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _profile(accounts: list[AccountNumber], threshold: float = 0.85) -> Profile:
+    return Profile(
+        subject=Subject(display_name="Test User", account_numbers=accounts),
+        detection=DetectionConfig(match_threshold=threshold),
+    )
+
+
+def _make_pdf(text: str) -> fitz.Document:
+    """Create a minimal single-page PDF with the given text."""
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 100), text, fontsize=12)
+    # Re-open from bytes so rawdict is available
+    buf = doc.tobytes()
+    return fitz.open(stream=buf, filetype="pdf")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _digits_only
+# ---------------------------------------------------------------------------
+
+def test_digits_only_strips_separators() -> None:
+    assert _digits_only("1234-5678-9012-3456") == "1234567890123456"
+
+
+def test_digits_only_plain() -> None:
+    assert _digits_only("1234567890123456") == "1234567890123456"
+
+
+def test_digits_only_empty() -> None:
+    assert _digits_only("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: mask_account_number
+# ---------------------------------------------------------------------------
+
+def test_mask_hyphenated_last4() -> None:
+    """1234-5678-9012-3456 -> XXXX-XXXX-XXXX-3456."""
+    assert mask_account_number("1234-5678-9012-3456", 4) == "XXXX-XXXX-XXXX-3456"
+
+
+def test_mask_plain_last4() -> None:
+    """Plain 16-digit number masked to last 4."""
+    assert mask_account_number("1234567890123456", 4) == "XXXXXXXXXXXX3456"
+
+
+def test_mask_preserve_zero_redacts_all() -> None:
+    """preserve_last=0 redacts all digits."""
+    assert mask_account_number("1234-5678", 0) == "XXXX-XXXX"
+
+
+def test_mask_preserve_more_than_length() -> None:
+    """preserve_last >= len(digits) keeps all digits."""
+    assert mask_account_number("1234", 6) == "1234"
+
+
+def test_mask_preserves_separators() -> None:
+    """Separators stay in their original positions."""
+    result = mask_account_number("12 34 56 78", 4)
+    assert result == "XX XX 56 78"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _find_account_in_text
+# ---------------------------------------------------------------------------
+
+def test_find_exact_match() -> None:
+    acct = AccountNumber(value="1234567890123456", preserve_last=4)
+    matches = _find_account_in_text("1234567890123456", acct)
+    assert len(matches) == 1
+    assert matches[0] == (0, 16)
+
+
+def test_find_hyphenated_in_text() -> None:
+    acct = AccountNumber(value="1234567890123456", preserve_last=4)
+    text = "Account: 1234-5678-9012-3456 end"
+    matches = _find_account_in_text(text, acct)
+    assert len(matches) == 1
+    start, end = matches[0]
+    assert text[start:end] == "1234-5678-9012-3456"
+
+
+def test_find_account_with_no_digits_returns_empty() -> None:
+    """Account value with no digits returns no matches (line 41 branch)."""
+    acct = AccountNumber(value="no-digits", preserve_last=1)
+    assert _find_account_in_text("some text 1234", acct) == []
+
+
+def test_find_no_match() -> None:
+    acct = AccountNumber(value="9999999999999999", preserve_last=4)
+    assert _find_account_in_text("1234-5678-9012-3456", acct) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: detect_account_numbers with real PDF
+# ---------------------------------------------------------------------------
+
+def test_detect_finds_account_in_pdf() -> None:
+    """Account number is detected in a synthetic PDF."""
+    doc = _make_pdf("Account: 1234-5678-9012-3456")
+    profile = _profile([AccountNumber(value="1234567890123456", preserve_last=4)])
+    detections = detect_account_numbers(doc, profile)
+    assert len(detections) >= 1
+    assert detections[0].entity_type == "ACCOUNT_NUMBER"
+    assert detections[0].preserve_last == 4
+
+
+def test_detect_no_accounts_in_profile_returns_empty() -> None:
+    """Profile with no account numbers returns empty list."""
+    doc = _make_pdf("1234-5678-9012-3456")
+    assert detect_account_numbers(doc, _profile([])) == []
+
+
+def test_detect_score_is_1() -> None:
+    """Account number detections have score=1.0 (exact match)."""
+    doc = _make_pdf("1234-5678-9012-3456")
+    profile = _profile([AccountNumber(value="1234567890123456", preserve_last=4)])
+    detections = detect_account_numbers(doc, profile)
+    assert all(d.score == 1.0 for d in detections)
+
+
+def test_detect_preserve_last_zero_uses_full_bbox() -> None:
+    """preserve_last=0 still produces a detection (full redaction)."""
+    doc = _make_pdf("1234-5678-9012-3456")
+    profile = _profile([AccountNumber(value="1234567890123456", preserve_last=0)])
+    detections = detect_account_numbers(doc, profile)
+    assert len(detections) >= 1
+    assert detections[0].preserve_last == 0
+
+
+def test_find_empty_account_value_returns_empty() -> None:
+    """Account with no digits returns no matches."""
+    assert _digits_only("") == ""
+    no_digit_acct = AccountNumber(value="no-digits", preserve_last=1)
+    assert _find_account_in_text("some text 1234", no_digit_acct) == []
+
+
+def test_mask_empty_string() -> None:
+    """mask_account_number on empty string returns empty string."""
+    assert mask_account_number("", 4) == ""
+
+
+def test_detect_page_with_no_text_blocks() -> None:
+    """PDF page with no text blocks returns empty detections."""
+    doc = fitz.open()
+    doc.new_page()  # blank page, no text
+    buf = doc.tobytes()
+    doc2 = fitz.open(stream=buf, filetype="pdf")
+    profile = _profile([AccountNumber(value="1234567890123456", preserve_last=4)])
+    assert detect_account_numbers(doc2, profile) == []
+
+
+def test_prefix_bbox_returns_none_when_all_digits_preserved() -> None:
+    """_prefix_bbox returns None when preserve_last >= number of digits."""
+    from redactron.redact.partial import _prefix_bbox
+    doc = _make_pdf("12")
+    page = doc[0]
+    # "12" has 2 digits; preserve_last=4 means nothing to redact
+    result = _prefix_bbox(page, "12", 0, 2, 4)
+    assert result is None
+
+
+def test_prefix_bbox_returns_none_when_text_not_found() -> None:
+    """_prefix_bbox returns None when full_text is not in page rawdict."""
+    from redactron.redact.partial import _prefix_bbox
+    doc = _make_pdf("hello world")
+    page = doc[0]
+    # full_text not present on page
+    result = _prefix_bbox(page, "9999999999999999", 0, 16, 4)
+    assert result is None
+
+
+def test_detect_prefix_bbox_fallback_when_none() -> None:
+    """When _prefix_bbox returns None, detection falls back to span bbox."""
+    # Use a 2-digit account with preserve_last=4 (more than digits) -> None from _prefix_bbox
+    doc = _make_pdf("Account: 12")
+    profile = _profile([AccountNumber(value="12", preserve_last=4)])
+    detections = detect_account_numbers(doc, profile)
+    # Should still produce a detection using span bbox fallback
+    assert len(detections) >= 1
+
+
+def test_detect_multipage_pdf() -> None:
+    """Account number found on page 2 has correct page_num."""
+    doc = fitz.open()
+    doc.new_page()  # page 0 — no account
+    page1 = doc.new_page()  # page 1
+    page1.insert_text((72, 100), "1234-5678-9012-3456", fontsize=12)
+    buf = doc.tobytes()
+    doc2 = fitz.open(stream=buf, filetype="pdf")
+    profile = _profile([AccountNumber(value="1234567890123456", preserve_last=4)])
+    detections = detect_account_numbers(doc2, profile)
+    assert len(detections) >= 1
+    assert detections[0].page_num == 1

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,143 @@
+"""Tests for src/redactron/profile.py (BLD-7)."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from redactron.errors import ProfileValidationError
+from redactron.profile import (
+    AccountNumber,
+    CustomPattern,
+    DetectionConfig,
+    Profile,
+    Subject,
+    load_profile,
+    save_profile,
+)
+
+SAMPLE_YAML = textwrap.dedent("""\
+    version: 1
+    name: default
+    subject:
+      display_name: "Tejinder Singh"
+      aliases: ["Tejinder", "T. Singh", "Singh, Tejinder"]
+      addresses:
+        - "100 Phillip Street, San Jose, CA 95020, USA"
+      phones: ["+1-408-555-1234"]
+      emails: ["tejinder.singh@ieee.org"]
+      ssns: ["xxx-xx-xxxx"]
+      account_numbers:
+        - value: "1234567890123456"
+          preserve_last: 4
+      custom_patterns:
+        - name: patient_id
+          regex: "PT-\\\\d{6}"
+    detection:
+      use_presidio: true
+      presidio_entities:
+        - PERSON
+        - LOCATION
+        - PHONE_NUMBER
+        - EMAIL_ADDRESS
+        - US_SSN
+        - CREDIT_CARD
+        - DATE_TIME
+      fuzzy_match: true
+      match_threshold: 0.85
+      full_token_min_length: 2
+      ocr_fallback: true
+""")
+
+
+def test_load_sample_profile(tmp_path: Path) -> None:
+    """Loads the sample profile from kickoff_prompt without errors."""
+    p = tmp_path / "profile.yaml"
+    p.write_text(SAMPLE_YAML)
+    profile = load_profile(p)
+    assert profile.version == 1
+    assert profile.subject.display_name == "Tejinder Singh"
+    assert len(profile.subject.aliases) == 3
+    assert profile.subject.account_numbers[0].preserve_last == 4
+    assert profile.detection.match_threshold == 0.85
+
+
+def test_load_minimal_profile(tmp_path: Path) -> None:
+    """Minimal profile with only required fields loads successfully."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("version: 1\nsubject:\n  display_name: Alice\n")
+    profile = load_profile(p)
+    assert profile.subject.display_name == "Alice"
+    assert profile.detection.use_presidio is True  # default
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    """Missing file raises ProfileValidationError."""
+    with pytest.raises(ProfileValidationError, match="not found"):
+        load_profile(tmp_path / "nonexistent.yaml")
+
+
+def test_invalid_yaml_raises(tmp_path: Path) -> None:
+    """Invalid YAML raises ProfileValidationError."""
+    p = tmp_path / "bad.yaml"
+    p.write_text("version: 1\nsubject: [unclosed")
+    with pytest.raises(ProfileValidationError, match="Invalid YAML"):
+        load_profile(p)
+
+
+def test_missing_display_name_raises(tmp_path: Path) -> None:
+    """Missing display_name raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("version: 1\nsubject:\n  aliases: []\n")
+    with pytest.raises(ProfileValidationError):
+        load_profile(p)
+
+
+def test_empty_display_name_raises(tmp_path: Path) -> None:
+    """Empty display_name raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text('version: 1\nsubject:\n  display_name: "  "\n')
+    with pytest.raises(ProfileValidationError, match="display_name"):
+        load_profile(p)
+
+
+def test_unsupported_version_raises(tmp_path: Path) -> None:
+    """Version != 1 raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("version: 2\nsubject:\n  display_name: Alice\n")
+    with pytest.raises(ProfileValidationError, match="version"):
+        load_profile(p)
+
+
+def test_invalid_threshold_raises() -> None:
+    """match_threshold outside [0,1] raises ValidationError."""
+    with pytest.raises(Exception):
+        DetectionConfig(match_threshold=1.5)
+
+
+def test_save_and_reload(tmp_path: Path) -> None:
+    """save_profile + load_profile round-trips correctly."""
+    profile = Profile(
+        subject=Subject(
+            display_name="Bob",
+            aliases=["Robert"],
+            account_numbers=[AccountNumber(value="9999888877776666", preserve_last=4)],
+            custom_patterns=[CustomPattern(name="emp_id", regex=r"EMP-\d{5}")],
+        )
+    )
+    path = tmp_path / "out.yaml"
+    save_profile(profile, path)
+    reloaded = load_profile(path)
+    assert reloaded.subject.display_name == "Bob"
+    assert reloaded.subject.aliases == ["Robert"]
+    assert reloaded.subject.account_numbers[0].value == "9999888877776666"
+
+
+def test_non_mapping_yaml_raises(tmp_path: Path) -> None:
+    """YAML that is not a mapping raises ProfileValidationError."""
+    p = tmp_path / "profile.yaml"
+    p.write_text("- item1\n- item2\n")
+    with pytest.raises(ProfileValidationError, match="mapping"):
+        load_profile(p)


### PR DESCRIPTION
## Summary
Implements `src/redactron/redact/partial.py` for account number detection and partial redaction.

## Bbox math approach
The key challenge is computing the bbox of only the prefix to redact (e.g., `1234-5678-9012-`) while leaving the last 4 digits (`3456`) visible.

**Approach:**
1. `detect_account_numbers()` walks the PDF's `get_text("rawdict")` to get per-span text
2. `_find_account_in_text()` matches the account number (digits-only comparison, ignoring separators like hyphens/spaces)
3. `_prefix_bbox()` re-reads rawdict char-level bboxes, finds the span text in the page's char sequence, then computes the union bbox of only the chars to redact (all chars up to and including the last non-preserved digit)
4. The resulting `Detection` has `preserve_last` set and a bbox covering only the prefix

**Edge cases covered:**
- Hyphenated format: `1234-5678-9012-3456` → bbox covers `1234-5678-9012-`
- Plain format: `1234567890123456` → bbox covers first 12 digits
- `preserve_last=0`: full span bbox used (complete redaction)
- `preserve_last >= digit_count`: returns None → falls back to span bbox (nothing to redact)
- Text not found in rawdict: returns None → falls back to span bbox
- Multi-page PDFs: correct `page_num` on each detection

## Test fixtures to inspect
- `test_detect_finds_account_in_pdf`: creates a synthetic PDF with `1234-5678-9012-3456`, verifies detection
- `test_detect_multipage_pdf`: verifies page_num is correct on page 1
- `test_prefix_bbox_returns_none_when_all_digits_preserved`: verifies the None fallback path
- `test_mask_hyphenated_last4`: verifies `XXXX-XXXX-XXXX-3456` output

## Changes
- `src/redactron/redact/partial.py`: detect + bbox math + mask utility
- `tests/test_partial.py`: 23 tests, 91% coverage
- `src/redactron/profile.py`: fix `AccountNumber.preserve_last` to allow 0

## Tested
`uv run pytest tests/test_partial.py` — 23/23 pass
`uv run ruff check` — clean
`uv run mypy src/redactron/redact/partial.py` — clean

⚠️ **Do NOT auto-merge** — awaiting manual review per BLD-10 exception rule.

Closes BLD-10