### PR TITLE
feat(audit): subjects table + --subject flag on run (BLD-15 / M3.3)

### DIFF
--- a/src/redactron/audit/log.py
+++ b/src/redactron/audit/log.py
@@ -186,3 +186,76 @@ def get_runs(
         return [dict(r) for r in rows]
     finally:
         conn.close()
+
+
+def add_subject(subject_id: str, display_name: str, db: Path | None = None) -> None:
+    """Create or update a subject entry.
+
+    Args:
+        subject_id: Unique slug identifier.
+        display_name: Human-readable name.
+        db: Optional path override.
+    """
+    path = db or _db_path()
+    conn = _connect(path)
+    try:
+        migrate(conn)
+        now = datetime.now(UTC).isoformat()
+        conn.execute(
+            """
+            INSERT INTO subjects (id, display_name, created_at, last_used_at, document_count)
+            VALUES (?, ?, ?, ?, 0)
+            ON CONFLICT(id) DO UPDATE SET display_name = excluded.display_name
+            """,
+            (subject_id, display_name, now, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def list_subjects(db: Path | None = None) -> list[dict]:  # type: ignore[type-arg]
+    """Return all subjects ordered by last_used_at desc.
+
+    Args:
+        db: Optional path override.
+
+    Returns:
+        List of dicts with subject row data.
+    """
+    path = db or _db_path()
+    if not path.exists():
+        return []
+    conn = _connect(path)
+    try:
+        migrate(conn)
+        rows = conn.execute(
+            "SELECT * FROM subjects ORDER BY last_used_at DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def get_subject(subject_id: str, db: Path | None = None) -> dict | None:  # type: ignore[type-arg]
+    """Fetch a single subject by ID.
+
+    Args:
+        subject_id: The subject slug.
+        db: Optional path override.
+
+    Returns:
+        Dict with subject data, or None if not found.
+    """
+    path = db or _db_path()
+    if not path.exists():
+        return None
+    conn = _connect(path)
+    try:
+        migrate(conn)
+        row = conn.execute(
+            "SELECT * FROM subjects WHERE id = ?", (subject_id,)
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()

--- a/src/redactron/audit/log.py
+++ b/src/redactron/audit/log.py
@@ -1,0 +1,188 @@
+"""SQLite audit log for redactron.
+
+Persists per-run records to ~/.redactron/audit.db (or REDACTRON_DB env var).
+Schema migrations are idempotent: safe to run on an existing database.
+
+BLD-14 (M3.2)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def _db_path() -> Path:
+    """Return the audit DB path, respecting REDACTRON_DB env override."""
+    env = os.environ.get("REDACTRON_DB")
+    if env:
+        return Path(env)
+    return Path.home() / ".redactron" / "audit.db"
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS documents (
+    id                          INTEGER PRIMARY KEY,
+    file_hash                   TEXT NOT NULL,
+    original_filename           TEXT,
+    output_filename             TEXT,
+    processed_at                TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    profile_name                TEXT,
+    subject_id                  TEXT,
+    pages_processed             INTEGER,
+    items_detected              INTEGER,
+    items_redacted              INTEGER,
+    verification_passed         BOOLEAN,
+    verification_survivors_json TEXT,
+    duration_ms                 INTEGER,
+    notes                       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS subjects (
+    id              TEXT PRIMARY KEY,
+    display_name    TEXT,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_used_at    TIMESTAMP,
+    document_count  INTEGER DEFAULT 0
+);
+"""
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    """Apply schema migrations. Idempotent — safe on existing databases."""
+    conn.executescript(_DDL)
+    conn.commit()
+
+
+@dataclass
+class DocumentRecord:
+    """One row in the documents audit table."""
+
+    file_hash: str
+    original_filename: str = ""
+    output_filename: str = ""
+    profile_name: str = ""
+    subject_id: str = ""
+    pages_processed: int = 0
+    items_detected: int = 0
+    items_redacted: int = 0
+    verification_passed: bool | None = None
+    verification_survivors: list[str] = field(default_factory=list)
+    duration_ms: int = 0
+    notes: str = ""
+    processed_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+def log_run(record: DocumentRecord, db: Path | None = None) -> int:
+    """Insert a DocumentRecord into the audit log and upsert subject stats.
+
+    Args:
+        record: The run record to persist.
+        db: Optional path override (defaults to _db_path()).
+
+    Returns:
+        The rowid of the inserted documents row.
+    """
+    path = db or _db_path()
+    conn = _connect(path)
+    try:
+        migrate(conn)
+        survivors_json = json.dumps(record.verification_survivors)
+        cur = conn.execute(
+            """
+            INSERT INTO documents (
+                file_hash, original_filename, output_filename,
+                processed_at, profile_name, subject_id,
+                pages_processed, items_detected, items_redacted,
+                verification_passed, verification_survivors_json,
+                duration_ms, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.file_hash,
+                record.original_filename,
+                record.output_filename,
+                record.processed_at.isoformat(),
+                record.profile_name,
+                record.subject_id,
+                record.pages_processed,
+                record.items_detected,
+                record.items_redacted,
+                record.verification_passed,
+                survivors_json,
+                record.duration_ms,
+                record.notes,
+            ),
+        )
+        rowid = cur.lastrowid or 0
+
+        if record.subject_id:
+            conn.execute(
+                """
+                INSERT INTO subjects (id, display_name, created_at, last_used_at, document_count)
+                VALUES (?, ?, ?, ?, 1)
+                ON CONFLICT(id) DO UPDATE SET
+                    last_used_at = excluded.last_used_at,
+                    document_count = document_count + 1
+                """,
+                (
+                    record.subject_id,
+                    record.subject_id,
+                    record.processed_at.isoformat(),
+                    record.processed_at.isoformat(),
+                ),
+            )
+
+        conn.commit()
+        return rowid
+    finally:
+        conn.close()
+
+
+def get_runs(
+    subject_id: str | None = None,
+    limit: int = 20,
+    db: Path | None = None,
+) -> list[dict]:  # type: ignore[type-arg]
+    """Fetch recent audit log entries.
+
+    Args:
+        subject_id: Filter by subject slug (None = all subjects).
+        limit: Maximum rows to return.
+        db: Optional path override.
+
+    Returns:
+        List of dicts with document row data.
+    """
+    path = db or _db_path()
+    if not path.exists():
+        return []
+    conn = _connect(path)
+    try:
+        migrate(conn)
+        if subject_id:
+            rows = conn.execute(
+                "SELECT * FROM documents WHERE subject_id = ? ORDER BY id DESC LIMIT ?",
+                (subject_id, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM documents ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()

--- a/src/redactron/cli.py
+++ b/src/redactron/cli.py
@@ -68,6 +68,7 @@ def run(
     ocr: bool = typer.Option(False, "--ocr", help="Enable OCR fallback for image pages."),
     no_verify: bool = typer.Option(False, "--no-verify", help="Skip post-redaction verification."),
     json_output: bool = typer.Option(False, "--json", help="Output results as JSON."),
+    subject: str = typer.Option("", "--subject", "-s", help="Subject slug for audit tagging."),
     debug: bool = typer.Option(False, "--debug", help="Show full stack traces on error."),
 ) -> None:
     """Redact PII from a PDF file or directory of PDFs."""
@@ -102,6 +103,7 @@ def run(
             threshold=threshold,
             verify=not no_verify,
             json_output=json_output,
+            subject_id=subject,
         )
     except RedactronError as exc:
         _error(str(exc), debug=debug, exc=exc)
@@ -116,6 +118,7 @@ def _run_pipeline(
     threshold: float,
     verify: bool,
     json_output: bool,
+    subject_id: str = "",
 ) -> None:
     """Orchestrate extract → detect → redact → verify for one or more PDFs."""
     from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
@@ -154,6 +157,7 @@ def _run_pipeline(
                 "input": str(result.input_path),
                 "output": str(result.output_path),
                 "detections": len(result.detections),
+                "subject": subject_id or None,
                 "verification": None,
             }
             if result.verification_passed is not None:
@@ -220,6 +224,57 @@ detection:
   full_token_min_length: 2
   ocr_fallback: false
 """
+
+# ---------------------------------------------------------------------------
+# subject subcommand group
+# ---------------------------------------------------------------------------
+
+subject_app = typer.Typer(name="subject", help="Manage redaction subjects.")
+app.add_typer(subject_app)
+
+
+@subject_app.command("add")
+def subject_add(
+    subject_id: str = typer.Argument(..., help="Subject slug (e.g. 'alice-smith')."),
+    display_name: str = typer.Option("", "--name", "-n", help="Display name."),
+) -> None:
+    """Create or update a subject entry in the audit log."""
+    from redactron.audit.log import add_subject
+
+    name = display_name or subject_id
+    add_subject(subject_id, name)
+    typer.echo(f"Subject '{subject_id}' ({name}) saved.")
+
+
+@subject_app.command("list")
+def subject_list() -> None:
+    """List all subjects in the audit log."""
+    from redactron.audit.log import list_subjects
+
+    subjects = list_subjects()
+    if not subjects:
+        typer.echo("No subjects found. Use `redactron subject add <id>` to create one.")
+        return
+    for s in subjects:
+        typer.echo(f"{s['id']:20s}  {s['display_name']:30s}  docs={s['document_count']}")
+
+
+@subject_app.command("show")
+def subject_show(
+    subject_id: str = typer.Argument(..., help="Subject slug."),
+) -> None:
+    """Show details for a specific subject."""
+    from redactron.audit.log import get_subject
+
+    s = get_subject(subject_id)
+    if s is None:
+        typer.echo(f"Subject '{subject_id}' not found.", err=True)
+        raise typer.Exit(1)
+    typer.echo(f"ID:             {s['id']}")
+    typer.echo(f"Display name:   {s['display_name']}")
+    typer.echo(f"Created:        {s['created_at']}")
+    typer.echo(f"Last used:      {s['last_used_at']}")
+    typer.echo(f"Document count: {s['document_count']}")
 
 
 if __name__ == "__main__":

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,146 @@
+"""Tests for the SQLite audit log (BLD-14 / M3.2)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from redactron.audit.log import DocumentRecord, get_runs, log_run, migrate
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> Path:
+    return tmp_path / "test_audit.db"
+
+
+class TestMigrate:
+    def test_creates_tables(self, db: Path) -> None:
+        conn = sqlite3.connect(str(db))
+        migrate(conn)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        assert "documents" in tables
+        assert "subjects" in tables
+        conn.close()
+
+    def test_idempotent(self, db: Path) -> None:
+        conn = sqlite3.connect(str(db))
+        migrate(conn)
+        migrate(conn)  # second call must not raise
+        conn.close()
+
+
+class TestLogRun:
+    def test_inserts_row(self, db: Path) -> None:
+        rec = DocumentRecord(file_hash="abc123", original_filename="test.pdf")
+        rowid = log_run(rec, db=db)
+        assert rowid == 1
+
+    def test_second_insert_increments(self, db: Path) -> None:
+        rec = DocumentRecord(file_hash="abc123")
+        log_run(rec, db=db)
+        rowid2 = log_run(rec, db=db)
+        assert rowid2 == 2
+
+    def test_all_fields_persisted(self, db: Path) -> None:
+        ts = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+        rec = DocumentRecord(
+            file_hash="deadbeef",
+            original_filename="in.pdf",
+            output_filename="out.pdf",
+            profile_name="default",
+            subject_id="alice",
+            pages_processed=5,
+            items_detected=3,
+            items_redacted=3,
+            verification_passed=True,
+            verification_survivors=[],
+            duration_ms=1234,
+            notes="test run",
+            processed_at=ts,
+        )
+        log_run(rec, db=db)
+        rows = get_runs(db=db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["file_hash"] == "deadbeef"
+        assert r["pages_processed"] == 5
+        assert r["items_detected"] == 3
+        assert r["verification_passed"] == 1  # SQLite stores bool as int
+        assert r["duration_ms"] == 1234
+        assert r["notes"] == "test run"
+
+    def test_subject_upsert_creates(self, db: Path) -> None:
+        rec = DocumentRecord(file_hash="x", subject_id="bob")
+        log_run(rec, db=db)
+        conn = sqlite3.connect(str(db))
+        row = conn.execute("SELECT * FROM subjects WHERE id='bob'").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[4] == 1  # document_count
+
+    def test_subject_upsert_increments(self, db: Path) -> None:
+        rec = DocumentRecord(file_hash="x", subject_id="carol")
+        log_run(rec, db=db)
+        log_run(rec, db=db)
+        conn = sqlite3.connect(str(db))
+        row = conn.execute("SELECT document_count FROM subjects WHERE id='carol'").fetchone()
+        conn.close()
+        assert row[0] == 2
+
+    def test_no_subject_skips_subjects_table(self, db: Path) -> None:
+        rec = DocumentRecord(file_hash="x", subject_id="")
+        log_run(rec, db=db)
+        conn = sqlite3.connect(str(db))
+        count = conn.execute("SELECT COUNT(*) FROM subjects").fetchone()[0]
+        conn.close()
+        assert count == 0
+
+    def test_verification_survivors_json(self, db: Path) -> None:
+        rec = DocumentRecord(
+            file_hash="x",
+            verification_passed=False,
+            verification_survivors=["Alice Sample", "alice@example.com"],
+        )
+        log_run(rec, db=db)
+        import json
+        rows = get_runs(db=db)
+        survivors = json.loads(rows[0]["verification_survivors_json"])
+        assert survivors == ["Alice Sample", "alice@example.com"]
+
+
+class TestGetRuns:
+    def test_empty_db_returns_empty(self, db: Path) -> None:
+        assert get_runs(db=db) == []
+
+    def test_missing_db_returns_empty(self, tmp_path: Path) -> None:
+        assert get_runs(db=tmp_path / "nonexistent.db") == []
+
+    def test_returns_most_recent_first(self, db: Path) -> None:
+        for i in range(5):
+            log_run(DocumentRecord(file_hash=f"hash{i}", notes=str(i)), db=db)
+        rows = get_runs(db=db)
+        assert rows[0]["notes"] == "4"
+        assert rows[-1]["notes"] == "0"
+
+    def test_limit(self, db: Path) -> None:
+        for i in range(10):
+            log_run(DocumentRecord(file_hash=f"h{i}"), db=db)
+        rows = get_runs(limit=3, db=db)
+        assert len(rows) == 3
+
+    def test_filter_by_subject(self, db: Path) -> None:
+        log_run(DocumentRecord(file_hash="a", subject_id="alice"), db=db)
+        log_run(DocumentRecord(file_hash="b", subject_id="bob"), db=db)
+        log_run(DocumentRecord(file_hash="c", subject_id="alice"), db=db)
+        rows = get_runs(subject_id="alice", db=db)
+        assert len(rows) == 2
+        assert all(r["subject_id"] == "alice" for r in rows)
+
+    def test_default_limit_20(self, db: Path) -> None:
+        for i in range(25):
+            log_run(DocumentRecord(file_hash=f"h{i}"), db=db)
+        rows = get_runs(db=db)
+        assert len(rows) == 20


### PR DESCRIPTION
- `add_subject()`, `list_subjects()`, `get_subject()` in audit/log.py
- `redactron subject add|list|show` CLI subcommands
- `--subject/-s` flag on `redactron run` for audit tagging

Closes BLD-15

---
Credits: 10 | Time: 350s