### PR TITLE
feat: BLD-32 migration from profile.yaml + secure-wipe

### DIFF
--- a/src/redactron/cli.py
+++ b/src/redactron/cli.py
@@ -79,6 +79,16 @@ def run(
     from redactron.profile import load_profile
 
     profile_path = Path(profile) if profile else default_profile_path()
+    vault_path = _default_vault_path()
+
+    # Backwards-compat: if vault exists and no explicit --profile, warn
+    if not profile and vault_path.exists() and profile_path.exists():
+        typer.echo(
+            "⚠️  Deprecation: both profile.yaml and vault.enc found. "
+            "Using profile.yaml. Migrate with: redactron profile import profile.yaml",
+            err=True,
+        )
+
     try:
         loaded_profile = load_profile(profile_path)
     except ProfileValidationError as exc:
@@ -695,6 +705,35 @@ def profile_rename(
     try:
         store.rename_profile(old_id, new_id)
         typer.echo(f"Profile '{old_id}' renamed to '{new_id}'.")
+    except Exception as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+
+@profile_app.command("import")
+def profile_import(
+    yaml_path: Path = typer.Argument(..., help="Legacy profile.yaml to import."),
+    client: str = typer.Option("", "--client", "-c", help="Client ID (default: filename stem)."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Validate without writing or wiping."),
+) -> None:
+    """Import a legacy profile.yaml into the vault and secure-wipe the source."""
+    import yaml
+
+    from redactron.vault.migrate import migrate_profile
+
+    client_id = client or yaml_path.stem
+    store = _get_vault_store()
+
+    if dry_run:
+        from redactron.vault.migrate import migrate_profile as _mp
+        profile_dict = _mp(yaml_path, client_id, store, dry_run=True)
+        typer.echo(f"[dry-run] Would import '{yaml_path}' as client '{client_id}':")
+        typer.echo(yaml.dump(profile_dict, default_flow_style=False))
+        return
+
+    try:
+        migrate_profile(yaml_path, client_id, store)
+        typer.echo(f"✅ Imported '{yaml_path}' as client '{client_id}'. Source file wiped.")
     except Exception as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1) from exc

--- a/src/redactron/vault/migrate.py
+++ b/src/redactron/vault/migrate.py
@@ -1,0 +1,61 @@
+"""Migration from legacy profile.yaml to encrypted vault (M3.5.4)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from redactron.vault.store import VaultStore
+
+
+def secure_wipe(path: Path) -> None:
+    """Overwrite file with random bytes 3 times, then unlink."""
+    size = path.stat().st_size
+    for _ in range(3):
+        with path.open("wb") as fh:
+            fh.write(os.urandom(max(size, 1)))
+            fh.flush()
+            os.fsync(fh.fileno())
+    path.unlink()
+
+
+def migrate_profile(
+    yaml_path: Path,
+    client_id: str,
+    store: VaultStore,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Validate and migrate a legacy profile.yaml into the vault.
+
+    Args:
+        yaml_path: Path to the legacy profile.yaml.
+        client_id: Target client ID in the vault.
+        store: VaultStore to write into.
+        dry_run: If True, validate and preview without writing or wiping.
+
+    Returns:
+        The profile dict that was (or would be) imported.
+
+    Raises:
+        ProfileValidationError: If the YAML fails Pydantic validation.
+        VaultError: If the vault operation fails.
+    """
+    from redactron.profile import load_profile
+
+    profile_obj = load_profile(yaml_path)
+    profile_dict = profile_obj.model_dump(mode="json")
+    display_name = profile_obj.subject.display_name
+
+    if dry_run:
+        return profile_dict
+
+    # Check if client_id already exists — update rather than error (idempotent)
+    existing = store.get_profile(client_id)
+    if existing is not None:
+        store.update_profile(client_id, profile_dict)
+    else:
+        store.add_profile(client_id, profile_dict, display_name)
+
+    secure_wipe(yaml_path)
+    return profile_dict

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,203 @@
+"""Tests for profile migration (BLD-32)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from redactron.cli import app
+from redactron.vault.migrate import migrate_profile, secure_wipe
+from redactron.vault.store import VaultStore
+
+runner = CliRunner()
+
+_SAMPLE_YAML = """\
+version: 1
+name: default
+subject:
+  display_name: "Alice Sample"
+  aliases: ["Alice"]
+  addresses: []
+  phones: []
+  emails: []
+  ssns: []
+  account_numbers: []
+  custom_patterns: []
+detection:
+  use_presidio: false
+  presidio_entities: []
+  fuzzy_match: true
+  match_threshold: 0.85
+  full_token_min_length: 2
+  ocr_fallback: false
+"""
+
+
+class StubBackend:
+    def __init__(self) -> None:
+        self._keys: dict[str, bytes] = {}
+
+    def get_or_create_master_key(self, vault_id: str) -> bytes:
+        if vault_id not in self._keys:
+            self._keys[vault_id] = os.urandom(32)
+        return self._keys[vault_id]
+
+    def delete_master_key(self, vault_id: str) -> None:
+        self._keys.pop(vault_id, None)
+
+
+def _make_store(tmp_path: Path) -> VaultStore:
+    return VaultStore(tmp_path / "vault.enc", StubBackend())
+
+
+# ---------------------------------------------------------------------------
+# secure_wipe
+# ---------------------------------------------------------------------------
+
+def test_secure_wipe_removes_file(tmp_path: Path) -> None:
+    f = tmp_path / "secret.yaml"
+    f.write_text("sensitive data")
+    secure_wipe(f)
+    assert not f.exists()
+
+
+def test_secure_wipe_overwrites_content(tmp_path: Path) -> None:
+    f = tmp_path / "secret.yaml"
+    original = "sensitive data 12345"
+    f.write_text(original)
+    # Capture content just before unlink by patching unlink
+    captured: list[bytes] = []
+    original_unlink = Path.unlink
+
+    def patched_unlink(self: Path, missing_ok: bool = False) -> None:  # type: ignore[override]
+        captured.append(self.read_bytes())
+        original_unlink(self, missing_ok=missing_ok)
+
+    with patch.object(Path, "unlink", patched_unlink):
+        secure_wipe(f)
+
+    assert captured, "unlink was not called"
+    assert original.encode() not in captured[-1], "Original content still present before unlink"
+
+
+# ---------------------------------------------------------------------------
+# migrate_profile
+# ---------------------------------------------------------------------------
+
+def test_migrate_profile_imports_and_wipes(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "profile.yaml"
+    yaml_path.write_text(_SAMPLE_YAML)
+    store = _make_store(tmp_path)
+
+    migrate_profile(yaml_path, "alice", store)
+
+    assert not yaml_path.exists(), "Source file should be wiped"
+    profile = store.get_profile("alice")
+    assert profile is not None
+    assert profile["subject"]["display_name"] == "Alice Sample"
+
+
+def test_migrate_profile_dry_run_no_write_no_wipe(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "profile.yaml"
+    yaml_path.write_text(_SAMPLE_YAML)
+    store = _make_store(tmp_path)
+
+    result = migrate_profile(yaml_path, "alice", store, dry_run=True)
+
+    assert yaml_path.exists(), "Source file must NOT be wiped in dry-run"
+    assert store.get_profile("alice") is None, "Vault must NOT be written in dry-run"
+    assert result["subject"]["display_name"] == "Alice Sample"
+
+
+def test_migrate_profile_idempotent(tmp_path: Path) -> None:
+    """Re-running with same client_id updates rather than errors."""
+    yaml_path = tmp_path / "profile.yaml"
+    yaml_path.write_text(_SAMPLE_YAML)
+    store = _make_store(tmp_path)
+    store.add_profile("alice", {"subject": {"display_name": "Old"}}, "Old")
+
+    # Write yaml again (it was wiped, so re-create)
+    yaml_path.write_text(_SAMPLE_YAML)
+    migrate_profile(yaml_path, "alice", store)
+
+    profile = store.get_profile("alice")
+    assert profile is not None
+    assert profile["subject"]["display_name"] == "Alice Sample"
+
+
+# ---------------------------------------------------------------------------
+# CLI: profile import
+# ---------------------------------------------------------------------------
+
+def test_cli_profile_import(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "profile.yaml"
+    yaml_path.write_text(_SAMPLE_YAML)
+    store = _make_store(tmp_path)
+
+    with patch("redactron.cli._get_vault_store", return_value=store):
+        result = runner.invoke(
+            app, ["profile", "import", str(yaml_path), "--client", "alice"]
+        )
+
+    assert result.exit_code == 0
+    assert "alice" in result.output
+    assert not yaml_path.exists()
+
+
+def test_cli_profile_import_dry_run(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "profile.yaml"
+    yaml_path.write_text(_SAMPLE_YAML)
+    store = _make_store(tmp_path)
+
+    with patch("redactron.cli._get_vault_store", return_value=store):
+        result = runner.invoke(
+            app, ["profile", "import", str(yaml_path), "--client", "alice", "--dry-run"]
+        )
+
+    assert result.exit_code == 0
+    assert "dry-run" in result.output
+    assert yaml_path.exists(), "Source must not be wiped in dry-run"
+    assert store.get_profile("alice") is None
+
+
+def test_cli_profile_import_default_client_id(tmp_path: Path) -> None:
+    """Default client_id is the filename stem."""
+    yaml_path = tmp_path / "myprofile.yaml"
+    yaml_path.write_text(_SAMPLE_YAML)
+    store = _make_store(tmp_path)
+
+    with patch("redactron.cli._get_vault_store", return_value=store):
+        result = runner.invoke(app, ["profile", "import", str(yaml_path)])
+
+    assert result.exit_code == 0
+    assert store.get_profile("myprofile") is not None
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat: run command warns when both profile.yaml and vault exist
+# ---------------------------------------------------------------------------
+
+def test_run_warns_when_both_exist(tmp_path: Path) -> None:
+    """run command emits deprecation warning when both profile.yaml and vault.enc exist."""
+    import fitz
+
+    profile_path = tmp_path / "profile.yaml"
+    profile_path.write_text(_SAMPLE_YAML)
+    vault_path = tmp_path / "vault.enc"
+    vault_path.write_bytes(b"fake")  # just needs to exist
+
+    pdf_path = tmp_path / "doc.pdf"
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(str(pdf_path))
+
+    with (
+        patch("redactron.cli._default_vault_path", return_value=vault_path),
+        patch("redactron.cli.default_profile_path", return_value=profile_path),
+    ):
+        result = runner.invoke(app, ["run", str(pdf_path)])
+
+    assert "Deprecation" in result.output or "deprecation" in result.output.lower()


### PR DESCRIPTION
Implements M3.5.4: profile import command + secure-wipe + backwards-compat.

265 tests passing | ruff clean | mypy clean

Closes BLD-32

---
Credits: 50 | Time: 900s