### PR TITLE
feat: BLD-33 --client flag on profile-using commands

### DIFF
--- a/src/redactron/cli.py
+++ b/src/redactron/cli.py
@@ -74,34 +74,38 @@ def run(
     subject: str = typer.Option("", "--subject", "-s", help="Subject slug for audit tagging."),
     no_report: bool = typer.Option(False, "--no-report", help="Skip writing report files."),
     debug: bool = typer.Option(False, "--debug", help="Show full stack traces on error."),
+    client: str = typer.Option("", "--client", "-c", help="Load profile from vault by client ID."),
 ) -> None:
     """Redact PII from a PDF file or directory of PDFs."""
     from redactron.profile import load_profile
 
-    profile_path = Path(profile) if profile else default_profile_path()
-    vault_path = _default_vault_path()
+    if client:
+        loaded_profile = _load_profile_for_client(client)
+    else:
+        profile_path = Path(profile) if profile else default_profile_path()
+        vault_path = _default_vault_path()
 
-    # Backwards-compat: if vault exists and no explicit --profile, warn
-    if not profile and vault_path.exists() and profile_path.exists():
-        typer.echo(
-            "⚠️  Deprecation: both profile.yaml and vault.enc found. "
-            "Using profile.yaml. Migrate with: redactron profile import profile.yaml",
-            err=True,
-        )
+        # Backwards-compat: if vault exists and no explicit --profile, warn
+        if not profile and vault_path.exists() and profile_path.exists():
+            typer.echo(
+                "⚠️  Deprecation: both profile.yaml and vault.enc found. "
+                "Using profile.yaml. Migrate with: redactron profile import profile.yaml",
+                err=True,
+            )
 
-    try:
-        loaded_profile = load_profile(profile_path)
-    except ProfileValidationError as exc:
-        msg = str(exc)
-        typer.echo(
-            f"❌ Profile error: {msg}\n"
-            "See docs/PROFILE.md for the full schema. Use --debug for details.",
-            err=True,
-        )
-        if debug:
-            import traceback
-            traceback.print_exc()
-        raise typer.Exit(1) from exc
+        try:
+            loaded_profile = load_profile(profile_path)
+        except ProfileValidationError as exc:
+            msg = str(exc)
+            typer.echo(
+                f"❌ Profile error: {msg}\n"
+                "See docs/PROFILE.md for the full schema. Use --debug for details.",
+                err=True,
+            )
+            if debug:
+                import traceback
+                traceback.print_exc()
+            raise typer.Exit(1) from exc
 
     log.info(
         "Loaded profile: %s (subject: %s)",
@@ -548,6 +552,21 @@ def _get_vault_store() -> VaultStore:  # noqa: F821
     from redactron.vault.store import VaultStore
 
     return VaultStore(_default_vault_path(), get_keychain_backend())
+
+
+def _load_profile_for_client(client_id: str) -> Profile:
+    """Load a Profile from the vault for the given client_id."""
+    store = _get_vault_store()
+    profile_dict = store.get_profile(client_id)
+    if profile_dict is None:
+        metas = store.list_profiles()
+        available = ", ".join(m.client_id for m in metas) or "(none)"
+        typer.echo(
+            f"Error: client '{client_id}' not found in vault. Available: {available}",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return Profile.model_validate(profile_dict)
 
 
 @vault_app.command("init")

--- a/tests/test_client_flag.py
+++ b/tests/test_client_flag.py
@@ -1,0 +1,125 @@
+"""Tests for --client flag on profile-using commands (BLD-33)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import fitz
+from typer.testing import CliRunner
+
+from redactron.cli import app
+from redactron.vault.store import VaultStore
+
+runner = CliRunner()
+
+_SAMPLE_PROFILE = {
+    "version": 1,
+    "name": "acme",
+    "subject": {
+        "display_name": "Acme Corp",
+        "aliases": [],
+        "addresses": [],
+        "phones": [],
+        "emails": [],
+        "ssns": [],
+        "account_numbers": [],
+        "custom_patterns": [],
+    },
+    "detection": {
+        "use_presidio": False,
+        "presidio_entities": [],
+        "fuzzy_match": True,
+        "match_threshold": 0.85,
+        "full_token_min_length": 2,
+        "ocr_fallback": False,
+    },
+}
+
+
+class StubBackend:
+    def __init__(self) -> None:
+        self._keys: dict[str, bytes] = {}
+
+    def get_or_create_master_key(self, vault_id: str) -> bytes:
+        if vault_id not in self._keys:
+            self._keys[vault_id] = os.urandom(32)
+        return self._keys[vault_id]
+
+    def delete_master_key(self, vault_id: str) -> None:
+        self._keys.pop(vault_id, None)
+
+
+def _make_store(tmp_path: Path) -> VaultStore:
+    return VaultStore(tmp_path / "vault.enc", StubBackend())
+
+
+def _make_pdf(tmp_path: Path, name: str = "doc.pdf") -> Path:
+    doc = fitz.open()
+    doc.new_page()
+    pdf_path = tmp_path / name
+    doc.save(str(pdf_path))
+    return pdf_path
+
+
+# ---------------------------------------------------------------------------
+# run --client
+# ---------------------------------------------------------------------------
+
+def test_run_client_loads_vault_profile(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    store.add_profile("acme", _SAMPLE_PROFILE, "Acme Corp")
+    pdf_path = _make_pdf(tmp_path)
+
+    with patch("redactron.cli._get_vault_store", return_value=store):
+        result = runner.invoke(
+            app,
+            ["run", str(pdf_path), "--client", "acme", "--no-verify", "--no-report"],
+        )
+    assert result.exit_code == 0
+
+
+def test_run_client_missing_shows_available(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    store.add_profile("alice", {}, "Alice")
+    pdf_path = _make_pdf(tmp_path)
+
+    with patch("redactron.cli._get_vault_store", return_value=store):
+        result = runner.invoke(
+            app, ["run", str(pdf_path), "--client", "ghost"]
+        )
+    assert result.exit_code == 1
+    assert "ghost" in result.output
+    assert "alice" in result.output
+
+
+# ---------------------------------------------------------------------------
+# _load_profile_for_client
+# ---------------------------------------------------------------------------
+
+def test_load_profile_for_client_success(tmp_path: Path) -> None:
+    from redactron.cli import _load_profile_for_client
+
+    store = _make_store(tmp_path)
+    store.add_profile("acme", _SAMPLE_PROFILE, "Acme Corp")
+
+    with patch("redactron.cli._get_vault_store", return_value=store):
+        profile = _load_profile_for_client("acme")
+    assert profile.subject.display_name == "Acme Corp"
+
+
+def test_load_profile_for_client_missing(tmp_path: Path) -> None:
+    import typer
+
+    from redactron.cli import _load_profile_for_client
+
+    store = _make_store(tmp_path)
+
+    with patch("redactron.cli._get_vault_store", return_value=store):
+        with patch("redactron.cli.typer.echo"):
+            try:
+                _load_profile_for_client("ghost")
+                assert False, "Should have raised Exit"
+            except typer.Exit as e:
+                assert e.exit_code == 1


### PR DESCRIPTION
Implements M3.5.5: --client flag on run command + vault profile loading.

269 tests passing | ruff clean | mypy clean

Closes BLD-33

---
Credits: 30 | Time: 600s