### PR TITLE
docs/fix: BLD-FIX-3 sync CLI surface docs to implementation

### DIFF
--- a/.kiro/kickoff_prompt.md
+++ b/.kiro/kickoff_prompt.md
@@ -659,7 +659,7 @@ redactron report <run_id>                            # re-render markdown report
 redactron dry-run <path> [--client, --json]         # preview without writing files
 redactron profile show [<id>] [--reveal] [--client]
 redactron profile edit [<id>] [--client]
-redactron profile add [--client <id>] [--from <yaml>]
+redactron profile add --client <id> [--name <name>] [--from <yaml>]
 redactron profile list
 redactron profile delete <id>
 redactron profile rename <old> <new>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,7 @@ def test_run_produces_output_file(tmp_path: Path) -> None:
 def test_run_json_output(tmp_path: Path) -> None:
     import json
     pdf = _make_pdf_file(tmp_path)
-    result = runner.invoke(app, ["run", str(pdf), "--no-verify", "--json"])
+    result = CliRunner(mix_stderr=False).invoke(app, ["run", str(pdf), "--no-verify", "--json"])
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert isinstance(data, list)
@@ -125,7 +125,7 @@ def test_batch_json_output_has_all_entries(tmp_path: Path) -> None:
     pdf_dir.mkdir()
     for i in range(3):
         _make_pdf_file(pdf_dir, f"doc{i}.pdf")
-    result = runner.invoke(
+    result = CliRunner(mix_stderr=False).invoke(
         app, ["run", str(pdf_dir), "--no-verify", "--json"]
     )
     assert result.exit_code == 0


### PR DESCRIPTION
Syncs kickoff_prompt.md CLI surface to match actual `redactron profile add` implementation.

- `--client` is required (not positional)
- `--name` is the display name flag (not `--display-name`)
- Also fixes 2 pre-existing test failures caused by deprecation warning on stderr mixing into JSON output

Closes BLD-40

---
Credits: 15 | Time: 300s