### PR TITLE
feat(ocr): pytesseract OCR fallback for image-only pages (BLD-19)

### DIFF
--- a/.kiro/specs/redactron/design.md
+++ b/.kiro/specs/redactron/design.md
@@ -269,3 +269,42 @@ All typed exceptions live in `redactron.errors`:
 - `VerificationError` — survivors found post-redaction
 
 CLI catches all and prints user-friendly messages; `--debug` shows full stack trace.
+
+## OCR Fallback (BLD-19)
+
+### Trigger
+Per-page auto-detection: if `len(page.get_text().strip()) < 50`, the page is
+treated as image-only and passed to Tesseract.  Mixed PDFs (some text pages,
+some image pages) are handled correctly — only image pages are OCR'd.
+
+### Coordinate conversion
+Tesseract returns bounding boxes in **pixel space** at the render DPI.
+PDF coordinates are in **points** (1 pt = 1/72 inch).  The conversion is:
+
+```
+scale = 72 / dpi          # e.g. 72/300 = 0.24
+pdf_x = pixel_x * scale
+```
+
+Omitting this scale factor would place redaction boxes ~4.17× too large at
+300 DPI (the default), causing severe over-redaction.
+
+### Confidence threshold
+Words with Tesseract confidence < 60 are skipped and counted in
+`OcrPageResult.low_conf_count`.  A warning is logged per page.
+
+### Sanity guards (reused thresholds)
+Same constants as `redact/engine.py`:
+- Reject word bbox covering > 30% of page area.
+- Reject word bbox taller than 4× median word height on that page.
+
+### Redaction strategy
+Image pages have no text content stream, so `page.add_redact_annot` has
+nothing to remove.  Instead, `paint_ocr_redactions` uses
+`page.draw_rect(rect, color=(0,0,0), fill=(0,0,0))` to paint black rectangles
+directly into the page content stream.
+
+### CLI flags
+`--ocr` / `--no-ocr` on the `run` command.  Default: `--no-ocr` (auto-detect
+still raises `NoTextLayerError` for fully image-only PDFs without the flag).
+

--- a/src/redactron/cli.py
+++ b/src/redactron/cli.py
@@ -123,6 +123,7 @@ def run(
             json_output=json_output,
             subject_id=subject,
             write_reports=not no_report,
+            ocr_enabled=ocr,
         )
     except RedactronError as exc:
         _error(str(exc), debug=debug, exc=exc)
@@ -139,6 +140,7 @@ def _run_pipeline(
     json_output: bool,
     subject_id: str = "",
     write_reports: bool = True,
+    ocr_enabled: bool = False,
 ) -> None:
     """Orchestrate extract → detect → redact → verify for one or more PDFs."""
     from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
@@ -172,6 +174,7 @@ def _run_pipeline(
                 score_threshold=threshold,
                 verify=verify,
                 write_reports=write_reports,
+                ocr_enabled=ocr_enabled,
             )
 
             r: dict[str, object] = {

--- a/src/redactron/extract/ocr.py
+++ b/src/redactron/extract/ocr.py
@@ -1,0 +1,226 @@
+"""OCR fallback for image-only PDF pages via pytesseract.
+
+Per-page auto-trigger: if a page has fewer than 50 characters of extractable
+text, it is rendered at ``DEFAULT_DPI`` and passed through Tesseract.
+
+Coordinate conversion
+---------------------
+Tesseract returns bounding boxes in *pixel space* at the render DPI.
+PDF coordinates are in *points* (1 pt = 1/72 inch).  The scale factor is::
+
+    scale = 72 / dpi          # e.g. 72/300 = 0.24
+
+Applying this converts pixel coords → PDF points.  Omitting it would place
+redaction boxes ~4× too large (at 300 DPI the raw pixel value is 4.17× the
+point value).
+
+Redaction strategy
+------------------
+OCR-derived spans have no underlying text stream to redact, so we paint the
+image region black with ``page.draw_rect(rect, color=(0,0,0), fill=(0,0,0))``.
+This is applied *before* ``page.apply_redactions()`` so the black fill is
+baked into the page content stream.
+
+Sanity guards (reused from redact/engine.py thresholds)
+--------------------------------------------------------
+* Reject any word bbox covering >30 % of page area.
+* Reject any word bbox taller than 4× the median word height on that page.
+  (Median is computed from the OCR word heights themselves for image pages.)
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass, field
+
+import fitz  # PyMuPDF
+
+log = logging.getLogger(__name__)
+
+DEFAULT_DPI: int = 300
+CONF_THRESHOLD: int = 60  # Tesseract confidence 0-100; below this → warn + skip
+
+# Reuse the same guard constants as redact/engine.py
+_MAX_RECT_PAGE_FRACTION = 0.30
+_MAX_HEIGHT_WORD_MULTIPLE = 4.0
+
+
+@dataclass(frozen=True, slots=True)
+class OcrWord:
+    """A single word detected by Tesseract with its PDF-space bounding box."""
+
+    page_num: int
+    text: str
+    bbox: tuple[float, float, float, float]  # x0, y0, x1, y1 in PDF points
+    conf: int  # Tesseract confidence 0-100
+
+
+@dataclass
+class OcrPageResult:
+    """OCR result for a single page."""
+
+    page_num: int
+    words: list[OcrWord] = field(default_factory=list)
+    low_conf_count: int = 0  # words below CONF_THRESHOLD (skipped)
+
+
+def _is_image_page(page: fitz.Page, min_chars: int = 50) -> bool:
+    """Return True if the page has fewer than min_chars of extractable text."""
+    return len(page.get_text().strip()) < min_chars
+
+
+def ocr_page(page: fitz.Page, page_num: int, dpi: int = DEFAULT_DPI) -> OcrPageResult:
+    """Run Tesseract on a single fitz.Page and return word-level results.
+
+    Args:
+        page: The fitz.Page to OCR.
+        page_num: Zero-based page index (for OcrWord.page_num).
+        dpi: Render resolution.  Higher = more accurate but slower.
+
+    Returns:
+        OcrPageResult with words in PDF point coordinates.
+    """
+    import pytesseract
+    from PIL import Image as _Image
+
+    result = OcrPageResult(page_num=page_num)
+    scale = 72.0 / dpi  # pixel → PDF point conversion factor
+
+    # Render page to a PIL image at the requested DPI
+    mat = fitz.Matrix(dpi / 72, dpi / 72)
+    pix = page.get_pixmap(matrix=mat, alpha=False)
+    img = _Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
+
+    # image_to_data returns a TSV-like dict with per-word bboxes + confidence
+    data = pytesseract.image_to_data(img, output_type=pytesseract.Output.DICT)
+
+    n = len(data["text"])
+    heights: list[float] = []
+
+    # First pass: collect heights for sanity guard median
+    for i in range(n):
+        try:
+            conf = int(data["conf"][i])
+        except (ValueError, TypeError):
+            continue
+        if conf < CONF_THRESHOLD:
+            continue
+        text = str(data["text"][i]).strip()
+        if not text:
+            continue
+        h = float(data["height"][i]) * scale
+        if h > 0:
+            heights.append(h)
+
+    median_h = statistics.median(heights) if heights else 12.0
+    page_area = page.rect.width * page.rect.height
+
+    # Second pass: build OcrWord list with sanity guards
+    for i in range(n):
+        try:
+            conf = int(data["conf"][i])
+        except (ValueError, TypeError):
+            continue
+
+        text = str(data["text"][i]).strip()
+        if not text:
+            continue
+
+        if conf < CONF_THRESHOLD:
+            result.low_conf_count += 1
+            log.debug("OCR page %d: low-conf word %r (conf=%d) — skipped", page_num, text, conf)
+            continue
+
+        # Convert pixel bbox → PDF points
+        x0 = float(data["left"][i]) * scale
+        y0 = float(data["top"][i]) * scale
+        x1 = x0 + float(data["width"][i]) * scale
+        y1 = y0 + float(data["height"][i]) * scale
+        w = x1 - x0
+        h = y1 - y0
+
+        rect_area = w * h
+        if rect_area > _MAX_RECT_PAGE_FRACTION * page_area:
+            log.warning(
+                "OCR page %d: word %r bbox covers %.0f%% of page — REJECTING",
+                page_num, text, rect_area / page_area * 100,
+            )
+            continue
+
+        if median_h > 0 and h > _MAX_HEIGHT_WORD_MULTIPLE * median_h:
+            log.warning(
+                "OCR page %d: word %r bbox height %.1f is %.1fx median — REJECTING",
+                page_num, text, h, h / median_h,
+            )
+            continue
+
+        result.words.append(OcrWord(
+            page_num=page_num,
+            text=text,
+            bbox=(x0, y0, x1, y1),
+            conf=conf,
+        ))
+
+    if result.low_conf_count:
+        log.warning(
+            "OCR page %d: %d low-confidence word(s) skipped (threshold=%d)",
+            page_num, result.low_conf_count, CONF_THRESHOLD,
+        )
+
+    return result
+
+
+def ocr_document(
+    doc: fitz.Document,
+    dpi: int = DEFAULT_DPI,
+    force: bool = False,
+) -> list[OcrPageResult]:
+    """OCR all image-only pages in a document.
+
+    Args:
+        doc: Open fitz.Document.
+        dpi: Render DPI (default 300).
+        force: If True, OCR every page regardless of text content.
+
+    Returns:
+        List of OcrPageResult, one per page that was OCR'd (skips text pages
+        unless force=True).
+    """
+    results: list[OcrPageResult] = []
+    for page_num in range(len(doc)):
+        page = doc[page_num]
+        if not force and not _is_image_page(page):
+            log.debug("OCR page %d: has text layer, skipping", page_num)
+            continue
+        log.info("OCR page %d: rendering at %d DPI", page_num, dpi)
+        results.append(ocr_page(page, page_num, dpi=dpi))
+    return results
+
+
+def paint_ocr_redactions(
+    page: fitz.Page,
+    words: list[OcrWord],
+    pii_texts: set[str],
+) -> int:
+    """Paint black rectangles over OCR words that match pii_texts.
+
+    Uses image-region painting (draw_rect with black fill) rather than
+    text-stream redaction, since image pages have no text stream.
+
+    Args:
+        page: The fitz.Page to paint on (mutated in place).
+        words: OCR words for this page.
+        pii_texts: Set of text strings to redact (case-insensitive match).
+
+    Returns:
+        Number of rectangles painted.
+    """
+    lower_pii = {t.lower() for t in pii_texts}
+    count = 0
+    for word in words:
+        if word.text.lower() in lower_pii:
+            rect = fitz.Rect(word.bbox)
+            page.draw_rect(rect, color=(0, 0, 0), fill=(0, 0, 0))
+            count += 1
+    return count

--- a/src/redactron/pipeline.py
+++ b/src/redactron/pipeline.py
@@ -92,6 +92,7 @@ def run_pipeline(
     score_threshold: float = 0.5,
     verify: bool = True,
     write_reports: bool = True,
+    ocr_enabled: bool = False,
 ) -> PipelineResult:
     """Run the full redaction pipeline with safety-net multi-pass.
 
@@ -105,6 +106,7 @@ def run_pipeline(
         profile: Loaded and validated Profile.
         score_threshold: Minimum score for Presidio detections.
         verify: Whether to run post-redaction verification.
+        ocr_enabled: If True, OCR image-only pages and paint redactions.
 
     Returns:
         PipelineResult with detections, safety_passes, and verification status.
@@ -124,16 +126,18 @@ def run_pipeline(
     total_chars = sum(len(page.get_text()) for page in doc)
     has_images = any(page.get_images() for page in doc)
     if total_chars < 50 and has_images:
-        doc.close()
-        raise NoTextLayerError(
-            "❌ This PDF appears to be a scan or image-only document with no text layer.\n"
-            "Redactron cannot detect text without OCR.\n"
-            "OCR support is coming in v1 milestone M4. Until then:\n"
-            "  1. Re-export from source application with 'searchable text', OR\n"
-            "  2. Run an OCR tool first (e.g., `ocrmypdf input.pdf output.pdf`)\n"
-            "     and pass the OCR'd file to redactron.\n"
-            "Run with --debug to see per-page character counts."
-        )
+        if not ocr_enabled:
+            doc.close()
+            raise NoTextLayerError(
+                "❌ This PDF appears to be a scan or image-only document with no text layer.\n"
+                "Redactron cannot detect text without OCR.\n"
+                "Re-run with --ocr to enable OCR fallback, or:\n"
+                "  1. Re-export from source application with 'searchable text', OR\n"
+                "  2. Run an OCR tool first (e.g., `ocrmypdf input.pdf output.pdf`)\n"
+                "     and pass the OCR'd file to redactron.\n"
+                "Run with --debug to see per-page character counts."
+            )
+        log.info("Image-only PDF detected; OCR fallback enabled.")
     # Work on an in-memory copy; mutate it across passes
     buf = doc.tobytes()
     working_doc = fitz.open(stream=buf, filetype="pdf")
@@ -186,6 +190,10 @@ def run_pipeline(
             "Safety net supplemented pass 1 on %d occasion(s); output is complete.",
             safety_passes,
         )
+
+    # OCR pass: paint redactions on image-only pages
+    if ocr_enabled:
+        _apply_ocr_redactions(working_doc, profile)
 
     # Save the final working doc
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -257,3 +265,32 @@ def _overlaps_any(
         if x0 < px1 and x1 > px0 and y0 < py1 and y1 > py0:
             return True
     return False
+
+
+def _apply_ocr_redactions(doc: fitz.Document, profile: Profile) -> None:
+    """OCR image-only pages and paint black over PII words.
+
+    Builds a set of PII strings from the profile (display_name, aliases,
+    phones, emails, SSNs) and matches them against OCR word text.
+    """
+    from redactron.extract.ocr import ocr_document, paint_ocr_redactions
+
+    pii_texts: set[str] = set()
+    subj = profile.subject
+    for part in subj.display_name.split():
+        pii_texts.add(part)
+    for alias in subj.aliases:
+        for part in alias.split():
+            pii_texts.add(part)
+    pii_texts.update(subj.phones)
+    pii_texts.update(subj.emails)
+    pii_texts.update(subj.ssns)
+    for an in subj.account_numbers:
+        pii_texts.add(an.value)
+
+    ocr_results = ocr_document(doc)
+    for page_result in ocr_results:
+        page = doc[page_result.page_num]
+        count = paint_ocr_redactions(page, page_result.words, pii_texts)
+        if count:
+            log.info("OCR page %d: painted %d redaction(s)", page_result.page_num, count)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,12 +1,22 @@
-"""Tests for src/redactron/extract/text_layer.py."""
+"""Tests for src/redactron/extract/text_layer.py and ocr.py."""
 
 import io
 from pathlib import Path
+from unittest.mock import patch
 
 import fitz
 import pytest
 
 from redactron.errors import ExtractionError
+from redactron.extract.ocr import (
+    CONF_THRESHOLD,
+    DEFAULT_DPI,
+    OcrPageResult,
+    OcrWord,
+    _is_image_page,
+    ocr_page,
+    paint_ocr_redactions,
+)
 from redactron.extract.text_layer import TextLayer, extract_text_layers, open_pdf
 
 
@@ -130,3 +140,188 @@ def test_extract_text_layers_page_error_raises() -> None:
 
     with pytest.raises(ExtractionError, match="Failed to extract text"):
         extract_text_layers(mock_doc)
+
+
+# ---------------------------------------------------------------------------
+# OCR module tests (BLD-19)
+# ---------------------------------------------------------------------------
+
+
+def _make_image_pdf() -> fitz.Document:
+    """Create a single-page PDF with an embedded image and no text layer."""
+    doc = fitz.open()
+    page = doc.new_page(width=612, height=792)
+    # Insert a small white rectangle as a stand-in image (no text)
+    page.draw_rect(fitz.Rect(0, 0, 612, 792), color=(1, 1, 1), fill=(1, 1, 1))
+    buf = io.BytesIO(doc.tobytes())
+    return fitz.open(stream=buf, filetype="pdf")
+
+
+def _make_text_pdf() -> fitz.Document:
+    """Create a single-page PDF with a text layer (>50 chars)."""
+    doc = fitz.open()
+    page = doc.new_page()
+    # Long enough to exceed the 50-char image-page threshold
+    page.insert_text((72, 72), "Hello World this is a text page with enough content", fontsize=12)
+    buf = io.BytesIO(doc.tobytes())
+    return fitz.open(stream=buf, filetype="pdf")
+
+
+def _mock_tesseract_data(words: list[tuple[str, int, int, int, int, int, int]]) -> dict:
+    """Build a pytesseract image_to_data DICT result.
+
+    Each tuple: (text, conf, left, top, width, height, level)
+    """
+    return {
+        "text": [w[0] for w in words],
+        "conf": [w[1] for w in words],
+        "left": [w[2] for w in words],
+        "top": [w[3] for w in words],
+        "width": [w[4] for w in words],
+        "height": [w[5] for w in words],
+        "level": [w[6] for w in words],
+    }
+
+
+def test_is_image_page_true_for_empty_page() -> None:
+    doc = _make_image_pdf()
+    assert _is_image_page(doc[0]) is True
+
+
+def test_is_image_page_false_for_text_page() -> None:
+    doc = _make_text_pdf()
+    assert _is_image_page(doc[0]) is False
+
+
+def test_ocr_word_dataclass_frozen() -> None:
+    w = OcrWord(page_num=0, text="hello", bbox=(0.0, 0.0, 10.0, 10.0), conf=90)
+    with pytest.raises(Exception):
+        w.text = "changed"  # type: ignore[misc]
+
+
+def test_ocr_page_returns_result_with_words() -> None:
+    """ocr_page with mocked tesseract returns OcrWord list."""
+    doc = _make_image_pdf()
+    page = doc[0]
+
+    mock_data = _mock_tesseract_data([
+        ("Alice", 95, 100, 100, 50, 15, 5),
+        ("Smith", 90, 160, 100, 50, 15, 5),
+    ])
+
+    with patch("pytesseract.image_to_data", return_value=mock_data):
+        result = ocr_page(page, page_num=0, dpi=DEFAULT_DPI)
+
+    assert isinstance(result, OcrPageResult)
+    assert len(result.words) == 2
+    assert result.words[0].text == "Alice"
+    assert result.words[1].text == "Smith"
+    assert result.low_conf_count == 0
+
+
+def test_ocr_page_dpi_scale_applied() -> None:
+    """Pixel coords are scaled by 72/dpi to PDF points."""
+    doc = _make_image_pdf()
+    page = doc[0]
+    dpi = 300
+    scale = 72.0 / dpi  # 0.24
+
+    mock_data = _mock_tesseract_data([
+        ("Test", 95, 100, 200, 60, 20, 5),
+    ])
+
+    with patch("pytesseract.image_to_data", return_value=mock_data):
+        result = ocr_page(page, page_num=0, dpi=dpi)
+
+    assert len(result.words) == 1
+    x0, y0, x1, y1 = result.words[0].bbox
+    assert abs(x0 - 100 * scale) < 0.01
+    assert abs(y0 - 200 * scale) < 0.01
+    assert abs(x1 - (100 + 60) * scale) < 0.01
+    assert abs(y1 - (200 + 20) * scale) < 0.01
+
+
+def test_ocr_page_low_conf_words_skipped() -> None:
+    """Words below CONF_THRESHOLD are counted but not returned."""
+    doc = _make_image_pdf()
+    page = doc[0]
+
+    mock_data = _mock_tesseract_data([
+        ("Good", 95, 10, 10, 30, 12, 5),
+        ("Bad", CONF_THRESHOLD - 1, 50, 10, 30, 12, 5),
+    ])
+
+    with patch("pytesseract.image_to_data", return_value=mock_data):
+        result = ocr_page(page, page_num=0)
+
+    assert len(result.words) == 1
+    assert result.words[0].text == "Good"
+    assert result.low_conf_count == 1
+
+
+def test_ocr_page_oversized_bbox_rejected() -> None:
+    """A word bbox covering >30% of page area is rejected."""
+    doc = _make_image_pdf()
+    page = doc[0]
+    # page is 612×792 pt; at 300 DPI that's 2550×3300 px
+    # A word covering 50% of the image in pixels → >30% of page area
+    mock_data = _mock_tesseract_data([
+        ("HUGE", 95, 0, 0, 2550, 1650, 5),  # 50% of page height
+    ])
+
+    with patch("pytesseract.image_to_data", return_value=mock_data):
+        result = ocr_page(page, page_num=0)
+
+    assert len(result.words) == 0
+
+
+def test_ocr_page_empty_text_skipped() -> None:
+    """Empty/whitespace text entries are ignored."""
+    doc = _make_image_pdf()
+    page = doc[0]
+
+    mock_data = _mock_tesseract_data([
+        ("", 95, 10, 10, 30, 12, 5),
+        ("  ", 95, 50, 10, 30, 12, 5),
+        ("Real", 95, 90, 10, 30, 12, 5),
+    ])
+
+    with patch("pytesseract.image_to_data", return_value=mock_data):
+        result = ocr_page(page, page_num=0)
+
+    assert len(result.words) == 1
+    assert result.words[0].text == "Real"
+
+
+def test_paint_ocr_redactions_paints_matching_words() -> None:
+    """paint_ocr_redactions draws rects for matching PII words."""
+    doc = _make_image_pdf()
+    page = doc[0]
+
+    words = [
+        OcrWord(page_num=0, text="Alice", bbox=(10.0, 10.0, 50.0, 25.0), conf=95),
+        OcrWord(page_num=0, text="Smith", bbox=(60.0, 10.0, 100.0, 25.0), conf=95),
+        OcrWord(page_num=0, text="Invoice", bbox=(10.0, 40.0, 80.0, 55.0), conf=95),
+    ]
+
+    count = paint_ocr_redactions(page, words, {"Alice", "Smith"})
+    assert count == 2
+
+
+def test_paint_ocr_redactions_case_insensitive() -> None:
+    """Matching is case-insensitive."""
+    doc = _make_image_pdf()
+    page = doc[0]
+
+    words = [OcrWord(page_num=0, text="ALICE", bbox=(10.0, 10.0, 50.0, 25.0), conf=95)]
+    count = paint_ocr_redactions(page, words, {"alice"})
+    assert count == 1
+
+
+def test_paint_ocr_redactions_no_match_returns_zero() -> None:
+    doc = _make_image_pdf()
+    page = doc[0]
+
+    words = [OcrWord(page_num=0, text="Invoice", bbox=(10.0, 10.0, 80.0, 25.0), conf=95)]
+    count = paint_ocr_redactions(page, words, {"Alice"})
+    assert count == 0


### PR DESCRIPTION
## Summary

Implements OCR fallback for image-only PDF pages via pytesseract.

### DPI conversion math
Tesseract returns bounding boxes in **pixel space** at the render DPI. PDF coordinates are in **points** (1 pt = 1/72 inch). The scale factor is:
```
scale = 72 / dpi   # e.g. 72/300 = 0.24
pdf_coord = pixel_coord * scale
```
Omitting this factor would place redaction boxes ~4.17× too large at 300 DPI (the default), causing severe over-redaction.

### Confidence threshold rationale
Tesseract confidence < 60 is skipped. Below 60, OCR errors are frequent enough that false-positive redactions (blacking out non-PII) become a real risk. Words below threshold are counted in `OcrPageResult.low_conf_count` and logged as warnings.

### Sanity guard reuse
Reuses the same constants from `redact/engine.py`:
- Reject bbox covering > 30% of page area
- Reject bbox taller than 4× median word height on that page

These prevent runaway redactions from Tesseract returning garbage bboxes on noisy scans.

### Redaction strategy
Image pages have no text content stream, so `page.add_redact_annot` has nothing to remove. Instead, `paint_ocr_redactions` uses `page.draw_rect(rect, color=(0,0,0), fill=(0,0,0))` to paint black rectangles directly into the page content stream.

### Fixtures used
All tests use mocked `pytesseract.image_to_data` — no real Tesseract binary required. In-memory fitz PDFs serve as image-page fixtures.

### Files changed
- `src/redactron/extract/ocr.py` (new) — OCR module
- `src/redactron/pipeline.py` — `ocr_enabled` param, `_apply_ocr_redactions` helper
- `src/redactron/cli.py` — wire `--ocr` flag through to pipeline
- `tests/test_extract.py` — 11 new OCR unit tests
- `.kiro/specs/redactron/design.md` — OCR section

Closes BLD-19

---
Credits: 28 | Time: 900s