### PR TITLE
docs(polish): README, PRIVACY.md, CHANGELOG.md, CONTRIBUTING.md (BLD-21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,72 @@
 # Changelog
 
-All notable changes to redactron will be documented here.
-
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-redactron uses [Semantic Versioning](https://semver.org/).
+All notable changes to redactron are documented here.
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning: [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.0] — 2026-05-03
+
+First public release. Covers milestones M1–M4 and M3.5.
+
 ### Added
-- Initial project bootstrap: pyproject.toml, .kiro specs, Linear project setup
+
+**M1 — Core engine**
+- PyMuPDF text extraction with character-level bounding boxes (`extract/text_layer.py`)
+- Name fuzzy-match detector via rapidfuzz (`detect/name_detector.py`)
+- Address detector via usaddress with multi-line bridge (`detect/address_detector.py`)
+- Account number / custom regex detector (`detect/account_detector.py`)
+- Presidio NLP detector with configurable entities (`detect/presidio_detector.py`)
+- Redaction engine with bbox sanity guards — rejects rects >30% page area or >4× median line height (`redact/engine.py`)
+- Partial-match account number redaction with `preserve_last` (`redact/partial.py`)
+- Post-redaction verification — re-scans output and reports survivors (`verify/verifier.py`)
+- Safety-net multi-pass pipeline — up to 3 passes until no survivors (`pipeline.py`)
+
+**M2 — Profile + variants**
+- Pydantic v2 profile schema with full validation (`profile.py`)
+- `redactron init` — creates default `~/.redactron/profile.yaml`
+- `redactron run` — redacts a file or directory with progress bar
+- `redactron dry-run` — previews detections without writing output
+- `redactron verify` — standalone verification of a redacted PDF
+- Batch mode — `redactron run ./docs/` redacts entire directories
+- JSON output mode (`--json`) for scripting
+- Audit log — SQLite record of every run (`audit/log.py`)
+- Markdown report generation (`report/markdown.py`)
+
+**M3 — Verification + audit**
+- `redactron log` — view audit history
+- `redactron report <id>` — re-render report from audit log
+- `redactron subject add/list/show` — subject management
+
+**M3.5 — Encrypted multi-client vault**
+- AES-256-GCM encrypted vault (`vault/store.py`, `vault/keychain.py`)
+- macOS Keychain integration with Touch ID via LocalAuthentication (`vault/keychain_macos.py`)
+- `redactron vault init` — creates encrypted vault
+- `redactron profile add/list/show/edit/delete/rename/import` — full profile CRUD
+- `redactron run --client <id>` — load profile from vault
+- Migration from legacy `profile.yaml` with secure-wipe (`vault/migrate.py`)
+
+**M4 — Polish + launch**
+- OCR fallback for image-only PDFs via pytesseract (`extract/ocr.py`)
+  - Per-page auto-trigger, 300 DPI render, 72/dpi coordinate conversion
+  - Confidence threshold 60, bbox sanity guards
+  - Image-region painting (draw_rect) for OCR redactions
+- `--ocr` / `--no-ocr` CLI flag on `redactron run`
+- Synthetic test corpus — 12 document types, 3 E2E assertions each (`tests/test_corpus.py`)
+- Full documentation: README, PROFILE.md, PRIVACY.md, SECURITY.md, CHANGELOG.md, CONTRIBUTING.md
+- PyPI release infrastructure (release.yml, trusted publishing)
+
+### Dependencies
+
+- pymupdf 1.24.11
+- presidio-analyzer / presidio-anonymizer 2.2.355
+- rapidfuzz 3.9.7
+- usaddress 0.5.10
+- pytesseract 0.3.13
+- typer 0.15.2
+- pydantic 2.9.2
+- cryptography 43.0.3
+- keyring 25.5.0
+
+[0.1.0]: https://github.com/tjndr/redactron/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to redactron
+
+## Dev setup
+
+```bash
+git clone https://github.com/tjndr/redactron
+cd redactron
+uv sync --all-extras
+```
+
+Requires: Python 3.11+, [uv](https://github.com/astral-sh/uv), Tesseract (for OCR tests).
+
+## Running tests
+
+```bash
+uv run pytest          # full suite with coverage
+uv run ruff check      # linter
+uv run mypy src/       # type checker (strict)
+```
+
+All three must pass before opening a PR.
+
+## Commits
+
+Conventional commits: `feat`, `fix`, `docs`, `test`, `chore`, `refactor`.
+
+```
+feat(ocr): add pytesseract fallback for image-only pages (BLD-19)
+fix(vault): correct nonce reuse guard on concurrent saves
+docs(profile): add numeric-matching gotchas section
+```
+
+Reference the Linear issue ID in the commit footer when applicable.
+
+## Pull requests
+
+- One Linear issue per PR.
+- Branch naming: `<milestone>/<issue-id>-short-desc` (e.g. `m4/bld-19-ocr-fallback`).
+- All tests must pass; no ruff or mypy errors.
+- PRs against `main`; squash merge.
+
+## Code style
+
+- ruff with default rules + isort, 100-char line length.
+- mypy strict for `src/redactron/`; lenient for `tests/`.
+- Google-style docstrings on all public functions.
+- No business logic in `cli.py` — orchestration only.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,113 @@
 # redactron
 
-> Local-only CLI for batch PII redaction in PDFs.
+> Local-only CLI for batch PII redaction in PDFs. No cloud. No telemetry. Verified output.
 
-**Status:** 🚧 Under active development — v1 target: 14 days
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://python.org)
 
 ## What it does
 
-redactron reads a profile YAML describing your PII (name aliases, addresses, phone numbers,
-emails, account numbers, custom patterns), redacts all matching text from PDFs using
-PyMuPDF, then verifies the redaction was complete. Everything runs on your machine — no
-cloud calls, ever.
+redactron reads a profile YAML describing your PII — name aliases, addresses, phone numbers,
+emails, account numbers, custom regex patterns — redacts all matching text from PDFs using
+PyMuPDF, then verifies the redaction was complete. Everything runs on your machine. No data
+ever leaves your device.
 
 ## Quickstart
 
 ```bash
-pip install redactron          # once published to PyPI
+pip install redactron
 redactron init                 # creates ~/.redactron/profile.yaml
-# edit profile.yaml with your details
-redactron run document.pdf     # redacts and verifies
+# edit ~/.redactron/profile.yaml with your details
+redactron run document.pdf     # redacts → document_redacted.pdf + verification report
+```
+
+## Features
+
+- **Profile-driven** — define your PII once in a YAML file; redact any number of PDFs
+- **Multi-detector** — name fuzzy-match, address parsing, account numbers, custom regex, Presidio NLP
+- **OCR fallback** — `--ocr` flag handles scanned/image-only PDFs via pytesseract
+- **Verification** — re-scans the redacted output and reports any survivors
+- **Multi-client vault** — AES-256-GCM encrypted vault for multiple client profiles
+- **Audit log** — SQLite log of every redaction run
+- **Batch mode** — `redactron run ./docs/` redacts an entire directory
+- **Dry run** — `redactron dry-run doc.pdf` previews detections without writing output
+
+## Profile example
+
+```yaml
+version: 1
+subject:
+  display_name: "Jane Smith"
+  aliases: ["Jane", "J. Smith"]
+  addresses: ["123 Main Street, Springfield, IL 62701"]
+  phones: ["+1-555-867-5309"]
+  emails: ["jane@example.com"]
+  account_numbers:
+    - value: "ACC-9900112233"
+      preserve_last: 4
+detection:
+  fuzzy_match: true
+  match_threshold: 0.85
+```
+
+See [docs/PROFILE.md](docs/PROFILE.md) for the full schema reference.
+
+## Multi-client vault
+
+```bash
+redactron vault init
+redactron profile add --client alice --name "Alice Smith"
+redactron profile add --client bob --from bob_profile.yaml
+redactron run statement.pdf --client alice
+redactron profile list
+```
+
+The vault is AES-256-GCM encrypted at rest. On macOS, the master key is stored in the
+login keychain and access is gated by a Touch ID prompt via LocalAuthentication.
+
+**Security model:** Touch ID is soft enforcement — it gates redactron's code path, not the
+keychain item itself. An unsigned Python package cannot use `kSecAttrAccessControl`
+(requires Apple code-signing entitlements). See [docs/SECURITY.md](docs/SECURITY.md) for
+the full threat model.
+
+## Performance targets (v1)
+
+| Scenario | Target |
+|---|---|
+| 10-page text PDF | < 3 seconds end-to-end |
+| 10-page image PDF (OCR) | < 30 seconds |
+| Peak memory per document | < 500 MB |
+
+## Platform support
+
+| Platform | Status |
+|---|---|
+| macOS | ✅ First-class (Touch ID vault) |
+| Linux | 🔜 v1.1 (keyring via libsecret) |
+| Windows | 🔜 v1.1 (DPAPI) |
+
+## CLI reference
+
+```
+redactron run <path> [--ocr] [--client <id>] [--no-verify] [--json] [--output <path>]
+redactron dry-run <path> [--json]
+redactron verify <path>
+redactron init
+redactron vault init
+redactron profile add --client <id> [--name <name>] [--from <yaml>]
+redactron profile list
+redactron profile show <id> [--reveal]
+redactron profile edit <id>
+redactron profile delete <id>
+redactron profile import <yaml> [--client <id>]
+redactron log [--subject <id>] [--limit N]
+redactron report <run-id>
 ```
 
 ## License
 
 AGPL-3.0 — see [LICENSE](LICENSE).
- # tiny diff
+
+redactron depends on [PyMuPDF](https://pymupdf.readthedocs.io/) which is also AGPL-3.0.
+If you distribute redactron as part of a proprietary product, the AGPL requires you to
+release your source. See [docs/PRIVACY.md](docs/PRIVACY.md) for details.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,101 @@
+# redactron — Privacy
+
+## Local-only guarantee
+
+redactron processes all PDFs entirely on your machine. There are no network calls in the
+redaction pipeline — not during detection, not during redaction, not during verification.
+This is enforced by design: the codebase has no HTTP client dependency and no outbound
+socket calls.
+
+You can verify this yourself:
+
+```bash
+# Run with network monitoring (macOS)
+sudo tcpdump -i any -n 'host not 0.0.0.0' &
+redactron run document.pdf
+# No packets should appear
+```
+
+## What data is stored locally
+
+### Audit log (`~/.redactron/audit.db`)
+
+SQLite database recording each redaction run:
+
+| Column | Value |
+|---|---|
+| `id` | Auto-increment integer |
+| `original_filename` | Filename only (no path) |
+| `output_filename` | Filename only |
+| `profile_name` | Profile `name` field |
+| `pages_processed` | Integer |
+| `items_detected` | Integer |
+| `items_redacted` | Integer |
+| `verification_passed` | Boolean |
+| `processed_at` | UTC timestamp |
+
+The audit log does **not** store: file paths, file contents, detected PII text, or any
+personally identifiable information beyond what you explicitly put in your profile name.
+
+### Encrypted vault (`~/.redactron/vault.enc`)
+
+AES-256-GCM encrypted blob containing your client profiles. Decrypted in-memory only;
+never written to disk in plaintext. See [SECURITY.md](SECURITY.md) for the full crypto
+specification.
+
+### Profile YAML (`~/.redactron/profile.yaml`)
+
+Plain-text YAML containing your PII definitions. This file is **not** encrypted by default.
+Protect it with filesystem permissions (`chmod 600`) or migrate to the vault:
+
+```bash
+redactron profile import ~/.redactron/profile.yaml --client default
+```
+
+## No telemetry
+
+redactron collects no usage data, crash reports, or analytics. There is no opt-out because
+there is nothing to opt out of.
+
+## Cloud sync warning
+
+If your home directory is synced to iCloud, Dropbox, or similar services:
+
+- `vault.enc` is safe to sync — it is opaque ciphertext without the keychain master key.
+- `profile.yaml` contains plaintext PII — **exclude it from sync** or migrate to the vault.
+- `audit.db` contains filenames and run metadata — exclude if you consider this sensitive.
+
+Add to your sync exclusion list:
+```
+~/.redactron/profile.yaml
+~/.redactron/audit.db
+```
+
+## AGPL-3.0 and PyMuPDF
+
+redactron is licensed under AGPL-3.0. It depends on
+[PyMuPDF](https://pymupdf.readthedocs.io/) (also AGPL-3.0).
+
+**What this means for you:**
+
+- **Personal use:** No restrictions. Use freely.
+- **Internal business use:** No restrictions. You are not distributing the software.
+- **Distribution as part of a proprietary product:** The AGPL requires you to release your
+  complete source code (including modifications) under AGPL-3.0 when you distribute the
+  combined work to users. This applies to SaaS if users interact with the software over a
+  network.
+
+If you need a commercial license for PyMuPDF that permits proprietary distribution, contact
+[Artifex Software](https://artifex.com/licensing/).
+
+## Comparison with cloud redaction services
+
+| Feature | redactron | Cloud services |
+|---|---|---|
+| Data leaves your machine | ❌ Never | ✅ Always |
+| Works offline | ✅ Yes | ❌ No |
+| Audit trail | ✅ Local SQLite | Varies |
+| Profile-driven | ✅ Yes | Rarely |
+| Verification | ✅ Built-in | Rarely |
+| Cost | Free (AGPL) | Per-page fees |
+| HIPAA/GLBA suitability | ✅ No BAA needed | Requires BAA |

--- a/docs/PROFILE.md
+++ b/docs/PROFILE.md
@@ -115,7 +115,7 @@ detection:
 
 **Figure text:** When `detection.scan_figures: false` (default), text inside figure/drawing regions is not redacted. Set `scan_figures: true` to include figure text (e.g., if your PDFs contain PII in chart labels or captions).
 
-**Image-only PDFs:** If a PDF has no extractable text layer (scanned document), redactron raises `NoTextLayerError` with a friendly message. OCR support is coming in M4. Until then, pre-process with `ocrmypdf input.pdf output.pdf`.
+**Image-only PDFs:** If a PDF has no extractable text layer (scanned document), use the `--ocr` flag to enable OCR fallback via pytesseract (requires Tesseract installed). Without `--ocr`, redactron raises `NoTextLayerError` with a friendly message. Default DPI: 300; confidence threshold: 60.
 
 ### Configuration reference
 


### PR DESCRIPTION
Documentation polish for v1 launch. README rewrite with honest security model. New PRIVACY.md, CHANGELOG.md, CONTRIBUTING.md. PROFILE.md updated for shipped --ocr flag. 322 tests pass.

Closes BLD-21

---
Credits: 12 | Time: 480s