### PR TITLE
feat(ocr): auto-trigger default; --no-ocr / --force-ocr flags (BLD-42)

### DIFF
--- a/src/redactron/cli.py
+++ b/src/redactron/cli.py
@@ -105,7 +105,8 @@ def run(
     profile: str = typer.Option("", "--profile", "-p", help="Profile YAML path."),
     output: str = typer.Option("", "--output", "-o", help="Output path."),
     threshold: float = typer.Option(0.5, "--threshold", "-t", help="Detection score threshold."),
-    ocr: bool = typer.Option(False, "--ocr", help="Enable OCR fallback for image pages."),
+    no_ocr: bool = typer.Option(False, "--no-ocr", help="Disable OCR on image-only pages."),
+    force_ocr: bool = typer.Option(False, "--force-ocr", help="Force OCR on every page."),
     no_verify: bool = typer.Option(False, "--no-verify", help="Skip post-redaction verification."),
     json_output: bool = typer.Option(False, "--json", help="Output results as JSON."),
     subject: str = typer.Option("", "--subject", "-s", help="Subject slug for audit tagging."),
@@ -160,7 +161,8 @@ def run(
             json_output=json_output,
             subject_id=subject,
             write_reports=not no_report,
-            ocr_enabled=ocr,
+            ocr_enabled=not no_ocr,
+            force_ocr=force_ocr,
         )
     except RedactronError as exc:
         _error(str(exc), debug=debug, exc=exc)
@@ -177,7 +179,8 @@ def _run_pipeline(
     json_output: bool,
     subject_id: str = "",
     write_reports: bool = True,
-    ocr_enabled: bool = False,
+    ocr_enabled: bool = True,
+    force_ocr: bool = False,
 ) -> None:
     """Orchestrate extract → detect → redact → verify for one or more PDFs."""
     from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
@@ -212,6 +215,7 @@ def _run_pipeline(
                 verify=verify,
                 write_reports=write_reports,
                 ocr_enabled=ocr_enabled,
+                force_ocr=force_ocr,
             )
 
             r: dict[str, object] = {
@@ -283,7 +287,7 @@ detection:
   fuzzy_match: true
   match_threshold: 0.85
   full_token_min_length: 2
-  ocr_fallback: false
+  ocr_fallback: true
 """
 
 # ---------------------------------------------------------------------------

--- a/src/redactron/pipeline.py
+++ b/src/redactron/pipeline.py
@@ -92,7 +92,8 @@ def run_pipeline(
     score_threshold: float = 0.5,
     verify: bool = True,
     write_reports: bool = True,
-    ocr_enabled: bool = False,
+    ocr_enabled: bool = True,
+    force_ocr: bool = False,
 ) -> PipelineResult:
     """Run the full redaction pipeline with safety-net multi-pass.
 
@@ -106,7 +107,8 @@ def run_pipeline(
         profile: Loaded and validated Profile.
         score_threshold: Minimum score for Presidio detections.
         verify: Whether to run post-redaction verification.
-        ocr_enabled: If True, OCR image-only pages and paint redactions.
+        ocr_enabled: If True (default), auto-OCR image-only pages via pytesseract.
+        force_ocr: If True, OCR every page regardless of text content.
 
     Returns:
         PipelineResult with detections, safety_passes, and verification status.
@@ -193,7 +195,7 @@ def run_pipeline(
 
     # OCR pass: paint redactions on image-only pages
     if ocr_enabled:
-        _apply_ocr_redactions(working_doc, profile)
+        _apply_ocr_redactions(working_doc, profile, force=force_ocr)
 
     # Save the final working doc
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -267,7 +269,7 @@ def _overlaps_any(
     return False
 
 
-def _apply_ocr_redactions(doc: fitz.Document, profile: Profile) -> None:
+def _apply_ocr_redactions(doc: fitz.Document, profile: Profile, force: bool = False) -> None:
     """OCR image-only pages and paint black over PII words.
 
     Builds a set of PII strings from the profile (display_name, aliases,
@@ -288,7 +290,7 @@ def _apply_ocr_redactions(doc: fitz.Document, profile: Profile) -> None:
     for an in subj.account_numbers:
         pii_texts.add(an.value)
 
-    ocr_results = ocr_document(doc)
+    ocr_results = ocr_document(doc, force=force)
     for page_result in ocr_results:
         page = doc[page_result.page_num]
         count = paint_ocr_redactions(page, page_result.words, pii_texts)

--- a/src/redactron/profile.py
+++ b/src/redactron/profile.py
@@ -68,7 +68,7 @@ class DetectionConfig(BaseModel):
     fuzzy_match: bool = True
     match_threshold: Annotated[float, Field(ge=0.0, le=1.0)] = 0.85
     full_token_min_length: Annotated[int, Field(ge=1)] = 2
-    ocr_fallback: bool = False
+    ocr_fallback: bool = True
     column_aware: bool = True   # reject cross-column address bridging
     scan_figures: bool = False  # skip text inside figure/drawing regions
     address_line_bridge_window: Annotated[int, Field(ge=0, le=10)] = 3


### PR DESCRIPTION
OCR now auto-triggers by default. --no-ocr disables, --force-ocr forces all pages. 323 tests pass.

Closes BLD-42

---
Credits: 6 | Time: 240s