### PR TITLE
docs(polish): sweep across all public markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,33 @@ Versioning: [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.1] — 2026-05-04
+
+### Fixed
+
+- `profile add --from` now secure-wipes the source YAML after vault write. Use `--keep-source` to opt out. (BLD-FIX-31)
+- `profile edit` crashed with `ValidationError` when the profile had a minimal schema. Fixed by using a hardcoded defaults dict instead of Pydantic instantiation. (BLD-FIX-34)
+
+### Changed
+
+- OCR auto-triggers by default on image-only pages. Use `--no-ocr` to disable, `--force-ocr` to OCR every page.
+- `redactron init` no longer creates `~/.redactron/profile.yaml`. It creates the directory and audit database only. Use `profile add --from` with the template instead.
+- Batch outputs go to `{input_dir}/redacted/`. Consolidated batch summary written to `{input_dir}/redacted-reports/`.
+- `--version` / `-V` top-level flag added. `redactron version` subcommand still works.
+- ASCII banner added to `run` and `version` output. Suppressed by `--quiet`, `--json`, or `NO_COLOR`.
+- `profile edit` pre-populates all schema fields with empty defaults so the full schema is visible.
+- `$EDITOR` parsed with `shlex.split` so editors with arguments (e.g. `code --wait`) work correctly.
+- Numeric span routing and OCR auto-trigger downgraded from `log.warning` to `log.debug`. A successful run at default log level produces no log output.
+
+### Added
+
+- `docs/examples/profile-template.yaml`: full annotated schema for the template-first workflow.
+- `--per-file-reports` flag on `run` (default off; consolidated report only).
+- `--keep-source` and `--dry-run` flags on `profile add --from`.
+
 ## [0.1.0] — 2026-05-03
 
-First public release. Covers milestones M1–M4 and M3.5.
+First public release. Covers milestones M1 through M4 and M3.5.
 
 ### Added
 
@@ -18,42 +42,38 @@ First public release. Covers milestones M1–M4 and M3.5.
 - Address detector via usaddress with multi-line bridge (`detect/address_detector.py`)
 - Account number / custom regex detector (`detect/account_detector.py`)
 - Presidio NLP detector with configurable entities (`detect/presidio_detector.py`)
-- Redaction engine with bbox sanity guards — rejects rects >30% page area or >4× median line height (`redact/engine.py`)
+- Redaction engine with bbox sanity guards. Rejects rects covering more than 30% of page area or taller than 4x median line height. (`redact/engine.py`)
 - Partial-match account number redaction with `preserve_last` (`redact/partial.py`)
-- Post-redaction verification — re-scans output and reports survivors (`verify/verifier.py`)
-- Safety-net multi-pass pipeline — up to 3 passes until no survivors (`pipeline.py`)
+- Post-redaction verification. Re-scans output and reports survivors. (`verify/verifier.py`)
+- Safety-net multi-pass pipeline. Up to 3 passes until no survivors. (`pipeline.py`)
 
 **M2 — Profile + variants**
 - Pydantic v2 profile schema with full validation (`profile.py`)
-- `redactron init` — creates default `~/.redactron/profile.yaml`
-- `redactron run` — redacts a file or directory with progress bar
-- `redactron dry-run` — previews detections without writing output
-- `redactron verify` — standalone verification of a redacted PDF
-- Batch mode — `redactron run ./docs/` redacts entire directories
+- `redactron init`
+- `redactron run` with progress bar
+- `redactron dry-run`
+- `redactron verify`
+- Batch mode: `redactron run ./docs/` redacts entire directories
 - JSON output mode (`--json`) for scripting
-- Audit log — SQLite record of every run (`audit/log.py`)
+- Audit log: SQLite record of every run (`audit/log.py`)
 - Markdown report generation (`report/markdown.py`)
 
 **M3 — Verification + audit**
-- `redactron log` — view audit history
-- `redactron report <id>` — re-render report from audit log
-- `redactron subject add/list/show` — subject management
+- `redactron log`
+- `redactron report <id>`
+- `redactron subject add/list/show`
 
 **M3.5 — Encrypted multi-client vault**
 - AES-256-GCM encrypted vault (`vault/store.py`, `vault/keychain.py`)
 - macOS Keychain integration with Touch ID via LocalAuthentication (`vault/keychain_macos.py`)
-- `redactron vault init` — creates encrypted vault
-- `redactron profile add/list/show/edit/delete/rename/import` — full profile CRUD
-- `redactron run --client <id>` — load profile from vault
+- `redactron vault init`
+- `redactron profile add/list/show/edit/delete/rename/import`
+- `redactron run --client <id>`
 - Migration from legacy `profile.yaml` with secure-wipe (`vault/migrate.py`)
 
 **M4 — Polish + launch**
-- OCR fallback for image-only PDFs via pytesseract (`extract/ocr.py`)
-  - Per-page auto-trigger, 300 DPI render, 72/dpi coordinate conversion
-  - Confidence threshold 60, bbox sanity guards
-  - Image-region painting (draw_rect) for OCR redactions
-- `--ocr` / `--no-ocr` CLI flag on `redactron run`
-- Synthetic test corpus — 12 document types, 3 E2E assertions each (`tests/test_corpus.py`)
+- OCR fallback for image-only PDFs via pytesseract (`extract/ocr.py`). Per-page auto-trigger, 300 DPI render, 72/dpi coordinate conversion, confidence threshold 60, bbox sanity guards.
+- Synthetic test corpus: 12 document types, 3 E2E assertions each (`tests/test_corpus.py`)
 - Full documentation: README, PROFILE.md, PRIVACY.md, SECURITY.md, CHANGELOG.md, CONTRIBUTING.md
 - PyPI release infrastructure (release.yml, trusted publishing)
 
@@ -69,4 +89,5 @@ First public release. Covers milestones M1–M4 and M3.5.
 - cryptography 43.0.3
 - keyring 25.5.0
 
+[0.1.1]: https://github.com/tjndr/redactron/releases/tag/v0.1.1
 [0.1.0]: https://github.com/tjndr/redactron/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,5 +66,5 @@ Be respectful. Harassment, discrimination, or personal attacks will not be toler
 - ruff with default rules + isort, 100-char line length.
 - mypy strict for `src/redactron/`; lenient for `tests/`.
 - Google-style docstrings on all public functions.
-- No business logic in `cli.py` — orchestration only.
+- No business logic in `cli.py`. Orchestration only.
 - `log.warning()` reserved for actual problems. Expected behavior (numeric span routing, OCR auto-trigger) uses `log.debug()`.

--- a/README.md
+++ b/README.md
@@ -6,40 +6,27 @@
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue)](https://python.org)
 
-Redactron is an on-device privacy tool for redacting PII from PDFs. Define your PII once in a profile, run it against any number of documents, and get a verified redacted output — all without a single byte leaving your machine.
+Redactron redacts PII from PDFs on your machine. No cloud. No telemetry. No subscriptions.
+
+Define your PII once in a profile, run it against any number of documents, and get a verified redacted output. The PDF never leaves your machine.
 
 Encrypted multi-client vault. Touch ID gated on macOS. Audit log. OCR fallback for scanned documents. AGPL-3.0.
 
 ---
 
-<!-- Demo GIF placeholder — add after first public release -->
+<!-- Demo GIF placeholder -->
 
 ---
 
 ## Why Redactron?
 
-**Your files stay local.** Every cloud redaction service — Adobe, iLovePDF, SmallPDF — uploads your documents to their servers. Redactron runs entirely on your machine. The PDF never leaves.
+Free online redactors are usually ad-supported and many run analytics on the documents you upload. For medical records, legal documents, or anything covered by HIPAA, GDPR, or attorney-client privilege, that is a serious concern. Adobe Acrobat uploads files to Adobe's servers. iLovePDF and SmallPDF are cloud services with freemium models. You have no visibility into what happens to your files after upload.
 
-**No subscription.** No per-page fees. No upsells. Install once, use forever.
+Redactron runs entirely on your machine. The codebase has no HTTP client dependency and no outbound socket calls. You can verify this with a packet capture while running a redaction.
 
-**Zero-trust, auditable source.** AGPL-3.0 means the full source is available for inspection. No black-box ML model deciding what to redact. You define exactly what gets removed.
+The source is AGPL-3.0 and available for inspection. There is no black-box model deciding what to redact. You define exactly what gets removed, and the tool re-scans the output to confirm it worked.
 
-**Professional-grade.** AES-256-GCM encrypted vault for multiple client profiles. Touch ID gate on macOS (via LocalAuthentication). SQLite audit log of every run. Post-redaction verification that re-scans the output and reports survivors.
-
-## Comparison
-
-| | Redactron | Adobe Acrobat | iLovePDF | SmallPDF |
-|---|:---:|:---:|:---:|:---:|
-| Files leave your machine? | ❌ Never | ✅ Cloud | ✅ Cloud | ✅ Cloud |
-| Subscription required? | ❌ Free | ✅ $20+/mo | ✅ Freemium | ✅ Freemium |
-| Ads / upsells? | ❌ None | ✅ Yes | ✅ Yes | ✅ Yes |
-| Audit log? | ✅ SQLite | ❌ No | ❌ No | ❌ No |
-| Multi-client support? | ✅ Encrypted vault | ❌ No | ❌ No | ❌ No |
-| Verification report? | ✅ Built-in | ❌ No | ❌ No | ❌ No |
-| Source available? | ✅ AGPL-3.0 | ❌ Proprietary | ❌ Proprietary | ❌ Proprietary |
-| Works offline? | ✅ Always | ⚠️ Partial | ❌ No | ❌ No |
-
-*Comparison reflects publicly available information as of May 2026. Cloud services may change their terms.*
+For professional use, the vault stores multiple client profiles encrypted with AES-256-GCM. The master key lives in the macOS login keychain, gated by Touch ID. Every run is logged to a local SQLite database.
 
 ## Quickstart
 
@@ -51,20 +38,20 @@ redactron profile add --client me --from docs/examples/profile-template.yaml
 redactron run document.pdf --client me
 ```
 
-That's it. `document_redacted.pdf` is in the same directory, alongside a verification report.
+`document_redacted.pdf` lands in the same directory, alongside a verification report.
 
 ## Features
 
-- **Profile-driven** — define your PII once (names, aliases, addresses, phones, emails, SSNs, account numbers, custom regex); redact any number of PDFs
-- **Encrypted vault** — AES-256-GCM encrypted multi-client profile store; master key in macOS Keychain
-- **Touch ID gate** — LocalAuthentication soft-gate before every vault access on macOS
-- **OCR fallback** — auto-triggers on image-only pages via pytesseract; no flag needed
-- **Layout-aware** — column-aware address bridging prevents cross-column false positives in two-column PDFs
-- **Verification** — re-scans the redacted output and reports any PII survivors
-- **Audit log** — SQLite record of every run (filename, detections, verification status)
-- **Batch mode** — `redactron run ./docs/` redacts an entire directory; outputs go to `redacted/` subdir
-- **Consolidated report** — single `YYYY-MM-DD-HHMM_batch-summary.md` per batch run
-- **Dry run** — preview detections without writing output
+- **Profile-driven.** Define your PII once (names, aliases, addresses, phones, emails, SSNs, account numbers, custom regex) and redact any number of PDFs.
+- **Encrypted vault.** AES-256-GCM encrypted multi-client profile store. Master key in macOS Keychain.
+- **Touch ID gate.** LocalAuthentication soft-gate before every vault access on macOS.
+- **OCR fallback.** Auto-triggers on image-only pages via pytesseract. No flag needed.
+- **Layout-aware.** Column-aware address bridging prevents cross-column false positives in two-column PDFs.
+- **Verification.** Re-scans the redacted output and reports any PII survivors.
+- **Audit log.** SQLite record of every run (filename, detections, verification status).
+- **Batch mode.** `redactron run ./docs/` redacts an entire directory. Outputs go to `redacted/` subdir.
+- **Consolidated report.** Single `YYYY-MM-DD-HHMM_batch-summary.md` per batch run.
+- **Dry run.** Preview detections without writing output.
 
 ## Profile example
 
@@ -100,7 +87,7 @@ redactron profile list
 
 The vault is AES-256-GCM encrypted at rest. On macOS, the master key is stored in the login keychain and access is gated by a Touch ID prompt via LocalAuthentication.
 
-**Touch ID is soft enforcement** — it gates redactron's code path, not the keychain item itself. An unsigned Python package cannot use `kSecAttrAccessControl` (requires Apple code-signing entitlements). See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model.
+Touch ID is soft enforcement. It gates redactron's code path, not the keychain item itself. An unsigned Python package cannot use `kSecAttrAccessControl` (requires Apple code-signing entitlements). See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model.
 
 ## Performance targets
 
@@ -114,9 +101,9 @@ The vault is AES-256-GCM encrypted at rest. On macOS, the master key is stored i
 
 | Platform | Status |
 |---|---|
-| macOS | ✅ First-class (Touch ID vault) |
-| Linux | 🔜 v1.1 (keyring via libsecret) |
-| Windows | 🔜 v1.1 (DPAPI) |
+| macOS | First-class (Touch ID vault) |
+| Linux | Planned for v1.1 (keyring via libsecret) |
+| Windows | Planned for v1.1 (DPAPI) |
 
 ## CLI reference
 
@@ -149,6 +136,6 @@ redactron --version
 
 ## License
 
-AGPL-3.0 — see [LICENSE](LICENSE).
+AGPL-3.0. See [LICENSE](LICENSE).
 
 Redactron depends on [PyMuPDF](https://pymupdf.readthedocs.io/) which is also AGPL-3.0. If you distribute redactron as part of a proprietary product, the AGPL requires you to release your source. See [docs/PRIVACY.md](docs/PRIVACY.md) for details.

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -3,9 +3,8 @@
 ## Local-only guarantee
 
 redactron processes all PDFs entirely on your machine. There are no network calls in the
-redaction pipeline — not during detection, not during redaction, not during verification.
-This is enforced by design: the codebase has no HTTP client dependency and no outbound
-socket calls.
+redaction pipeline: not during detection, not during redaction, not during verification.
+The codebase has no HTTP client dependency and no outbound socket calls.
 
 You can verify this yourself:
 
@@ -34,7 +33,7 @@ SQLite database recording each redaction run:
 | `verification_passed` | Boolean |
 | `processed_at` | UTC timestamp |
 
-The audit log does **not** store: file paths, file contents, detected PII text, or any
+The audit log does **not** store file paths, file contents, detected PII text, or any
 personally identifiable information beyond what you explicitly put in your profile name.
 
 ### Encrypted vault (`~/.redactron/vault.enc`)
@@ -61,9 +60,9 @@ there is nothing to opt out of.
 
 If your home directory is synced to iCloud, Dropbox, or similar services:
 
-- `vault.enc` is safe to sync — it is opaque ciphertext without the keychain master key.
-- `profile.yaml` contains plaintext PII — **exclude it from sync** or migrate to the vault.
-- `audit.db` contains filenames and run metadata — exclude if you consider this sensitive.
+- `vault.enc` is safe to sync. It is opaque ciphertext without the keychain master key.
+- `profile.yaml` contains plaintext PII. Exclude it from sync or migrate to the vault.
+- `audit.db` contains filenames and run metadata. Exclude it if you consider this sensitive.
 
 Add to your sync exclusion list:
 ```
@@ -88,14 +87,23 @@ redactron is licensed under AGPL-3.0. It depends on
 If you need a commercial license for PyMuPDF that permits proprietary distribution, contact
 [Artifex Software](https://artifex.com/licensing/).
 
-## Comparison with cloud redaction services
+## Compared to cloud redaction services
+
+Free online redactors are usually ad-supported and many run analytics on the documents you
+upload. For medical records, legal documents, or anything covered by HIPAA, GDPR, or
+attorney-client privilege, that is a serious concern. Adobe Acrobat uploads files to
+Adobe's servers. iLovePDF and SmallPDF are cloud services with freemium models. You have
+no visibility into what happens to your files after upload.
+
+redactron has no network calls in the redaction pipeline. The codebase has no HTTP client
+dependency. You can verify this with a packet capture.
 
 | Feature | redactron | Cloud services |
 |---|---|---|
-| Data leaves your machine | ❌ Never | ✅ Always |
-| Works offline | ✅ Yes | ❌ No |
-| Audit trail | ✅ Local SQLite | Varies |
-| Profile-driven | ✅ Yes | Rarely |
-| Verification | ✅ Built-in | Rarely |
+| Data leaves your machine | Never | Always |
+| Works offline | Yes | No |
+| Audit trail | Local SQLite | Varies |
+| Profile-driven | Yes | Rarely |
+| Verification | Built-in | Rarely |
 | Cost | Free (AGPL) | Per-page fees |
-| HIPAA/GLBA suitability | ✅ No BAA needed | Requires BAA |
+| HIPAA/GLBA suitability | No BAA needed | Requires BAA |

--- a/docs/PROFILE.md
+++ b/docs/PROFILE.md
@@ -1,7 +1,7 @@
 # redactron Profile Reference
 
 A profile YAML file tells redactron **what to redact** and **how to detect it**.
-By default, redactron runs in **profile-only mode** — it redacts exactly what you declare, nothing more.
+By default, redactron runs in **profile-only mode**. it redacts exactly what you declare, nothing more.
 
 ---
 
@@ -26,7 +26,7 @@ detection:
 ```
 
 Redacts only the names, addresses, account numbers, and patterns you declare.
-**Deterministic and privacy-preserving** — no ML model, no false positives from unrelated text.
+**Deterministic and privacy-preserving**. no ML model, no false positives from unrelated text.
 
 ### Profile + Presidio mode (opt-in)
 
@@ -41,7 +41,7 @@ detection:
     - CREDIT_CARD
 ```
 
-Adds Microsoft Presidio NER on top of profile detection. Profile hits are **authoritative** — they always win over Presidio on overlapping spans. Only the entity types you list are detected; there are no implicit defaults.
+Adds Microsoft Presidio NER on top of profile detection. Profile hits are **authoritative**. they always win over Presidio on overlapping spans. Only the entity types you list are detected; there are no implicit defaults.
 
 **Why profile-only is the v1 default:** Presidio can produce false positives (acquisition dates, market values, unrelated names). Profile-only mode gives you a deterministic privacy guarantee: only your declared PII is redacted.
 
@@ -107,7 +107,7 @@ detection:
 - **No-comma variants**: "100 Phillip St San Jose CA 95020" matches
 - **Multi-line**: each PDF text span is matched independently; a multi-line address produces one detection per line
 
-**Known limitation — house number disambiguation:** At the default threshold (0.85), "200 Phillip Street" will match a profile address of "100 Phillip Street" because they differ by only one character (~97% similar). To distinguish house numbers, raise `match_threshold` to 0.99 — but this may miss abbreviated or slightly misspelled forms. This is a v1 limitation; v2 will use structured address comparison.
+**Known limitation. house number disambiguation:** At the default threshold (0.85), "200 Phillip Street" will match a profile address of "100 Phillip Street" because they differ by only one character (~97% similar). To distinguish house numbers, raise `match_threshold` to 0.99. but this may miss abbreviated or slightly misspelled forms. This is a v1 limitation; v2 will use structured address comparison.
 
 ### Layout handling
 
@@ -132,7 +132,7 @@ Many PDFs render addresses across multiple lines (street on one line, city/state
 
 1. A line that parses as a street address (has a house number + street name) becomes an anchor.
 2. The detector looks forward up to `address_line_bridge_window` (default: 3) subsequent lines for continuation content: city/state/zip lines, occupancy lines (Suite, Apt, Unit), or empty lines.
-3. If a continuation is found, all constituent lines are matched together against the profile address. On a match, **each line gets its own redaction bbox** — no single giant rectangle.
+3. If a continuation is found, all constituent lines are matched together against the profile address. On a match, **each line gets its own redaction bbox**. no single giant rectangle.
 4. Bridging **stops immediately** if a prose line is encountered (more than 6 tokens with no ZIP or state abbreviation). This prevents bridging across account headers, footnotes, or other non-address content.
 
 Configure the window in your profile:
@@ -204,39 +204,39 @@ Understanding how each field type is matched prevents surprises:
 | Account numbers | Exact digit match (separators stripped) | Fuzzy on digits causes catastrophic over-redaction |
 | Custom patterns | Regex with `re.finditer` | Exact by definition |
 
-### Numeric tokens — exact-match only (guaranteed)
+### Numeric tokens. exact-match only (guaranteed)
 
 **Numeric tokens are never fuzzy-matched.** This is a hard guarantee, not a configuration option.
 
-A span is considered numeric if it contains only digits, spaces, hyphens, dots, and commas — for example:
+A span is considered numeric if it contains only digits, spaces, hyphens, dots, and commas. for example:
 - `103 9.22` (table cell with embedded space)
 - `1,234.56` (formatted number)
 - `95020` (ZIP code)
 - `1234-5678` (reference number)
 
-When the address detector encounters a numeric span, it logs a `WARNING` and skips fuzzy comparison:
+When the address detector encounters a numeric span, it logs a debug message and skips fuzzy comparison:
 
 ```
-WARNING Skipping fuzzy match for numeric span '103 9.22' (exact-match only).
+DEBUG Skipping fuzzy match for numeric span '103 9.22' (exact-match only).
         This prevents over-redaction of unrelated digits.
 ```
 
 This prevents table columns with quantities, prices, or reference numbers from being accidentally redacted because they share digits with a ZIP code or house number in your profile address.
 
-### Safety-net multi-pass — normal operation, not an error
+### Safety-net multi-pass. normal operation, not an error
 
-After applying redactions, the pipeline re-extracts the redacted PDF and re-runs all detectors (up to 3 passes total). If pass 2 or 3 finds additional spans, they are redacted and an **INFO** message is logged:
+After applying redactions, the pipeline re-extracts the redacted PDF and re-runs all detectors (up to 3 passes total). If pass 2 or 3 finds additional spans, they are redacted and a debug message is logged:
 
 ```
 Pass 2 supplemented pass 1 with 2 additional spans; output is complete.
 (Detector gap on this input; please report if reproducible on a non-edge-case PDF.)
 ```
 
-**This is normal.** Many edge-case PDFs (complex layouts, multi-column tables, OCR artifacts) trigger the safety net. The output is always complete and correct — the safety net is a defense-in-depth mechanism, not a sign of failure. You do not need to take any action.
+**This is normal.** Many edge-case PDFs (complex layouts, multi-column tables, OCR artifacts) trigger the safety net. The output is always complete and correct. the safety net is a defense-in-depth mechanism, not a sign of failure. You do not need to take any action.
 
 `WARNING`-level messages in the pipeline are reserved for actual problems: a redaction bbox rejected as too large, or `MAX_PASSES` exceeded on pathological input.
 
-### Reports — written by default
+### Reports. written by default
 
 Every successful `redactron run` writes two report files alongside the redacted PDF:
 
@@ -254,7 +254,7 @@ redactron run document.pdf --no-report
 
 ### Exhaustive detection
 
-Every detector scans **all occurrences** on every page. If an account number appears in the header, body table, and footer of a PDF, all three are detected and redacted. There is no deduplication by text value — each bbox span is a separate redaction target.
+Every detector scans **all occurrences** on every page. If an account number appears in the header, body table, and footer of a PDF, all three are detected and redacted. There is no deduplication by text value. each bbox span is a separate redaction target.
 
 ---
 
@@ -298,7 +298,7 @@ redactron profile add --client acme --from profile.yaml
 redactron profile list
 ```
 
-Shows client IDs and display names only — no PII.
+Shows client IDs and display names only. no PII.
 
 ### Showing a profile
 
@@ -306,7 +306,7 @@ Shows client IDs and display names only — no PII.
 # Masked (default)
 redactron profile show acme
 
-# Unmasked — requires TTY + confirmation + Touch ID
+# Unmasked. requires TTY + confirmation + Touch ID
 redactron profile show acme --reveal
 ```
 
@@ -335,7 +335,7 @@ redactron run invoice.pdf --client bob
 - Touch ID prompts once per CLI invocation (not once per profile lookup)
 - If Touch ID is unavailable, macOS falls back to your login password
 - Cancelling the prompt shows: "Touch ID authentication failed or was cancelled. Cannot unlock the vault."
-- Works without an Apple Developer account or code signing — uses LocalAuthentication framework
+- Works without an Apple Developer account or code signing. uses LocalAuthentication framework
 - Running in CI/headless: use `--profile` flag with a legacy YAML instead
 
 ### Backwards compatibility
@@ -356,7 +356,7 @@ cp docs/examples/profile-template.yaml /tmp/alice.yaml
 # 2. Fill in values (open in your editor)
 $EDITOR /tmp/alice.yaml
 
-# 3. Import into the vault — source file is secure-wiped after import
+# 3. Import into the vault. source file is secure-wiped after import
 redactron profile add --client alice --from /tmp/alice.yaml
 
 # 4. Verify
@@ -374,11 +374,11 @@ The source YAML is overwritten with random bytes and deleted after a successful 
 **Symptom:** `redactron run doc.pdf` reports 0 detections.
 
 **Causes and fixes:**
-1. **Profile not loaded** — check `redactron profile list` or `redactron profile show <id>`. If empty, add a profile first.
-2. **display_name doesn't match** — the name in the PDF may be spelled differently. Add aliases: `aliases: ["Jane", "J. Smith", "Smith, Jane"]`.
-3. **Fuzzy threshold too high** — lower `match_threshold` from 0.85 to 0.75 for more permissive matching.
-4. **Image-only PDF** — OCR is on by default. If Tesseract isn't installed, install it: `brew install tesseract` (macOS) or `apt install tesseract-ocr` (Linux).
-5. **Wrong profile** — if using `--client`, confirm the client ID: `redactron profile list`.
+1. **Profile not loaded**. check `redactron profile list` or `redactron profile show <id>`. If empty, add a profile first.
+2. **display_name doesn't match**. the name in the PDF may be spelled differently. Add aliases: `aliases: ["Jane", "J. Smith", "Smith, Jane"]`.
+3. **Fuzzy threshold too high**. lower `match_threshold` from 0.85 to 0.75 for more permissive matching.
+4. **Image-only PDF**. OCR is on by default. If Tesseract isn't installed, install it: `brew install tesseract` (macOS) or `apt install tesseract-ocr` (Linux).
+5. **Wrong profile**. if using `--client`, confirm the client ID: `redactron profile list`.
 
 ### OCR not triggering
 
@@ -403,6 +403,6 @@ Use `--force-ocr` to OCR every page regardless of text content.
 **Symptom:** `verification_passed: false` with survivors listed.
 
 **Causes:**
-1. **Fuzzy match missed a variant** — add the surviving text as an alias.
-2. **Numeric span not redacted** — account numbers with only digits need `custom_patterns` with a regex, or `use_presidio: true` with appropriate entities.
-3. **OCR-derived text** — if the PDF has both text and image layers, some text may come from the image layer. Use `--force-ocr` to OCR all pages.
+1. **Fuzzy match missed a variant**. add the surviving text as an alias.
+2. **Numeric span not redacted**. account numbers with only digits need `custom_patterns` with a regex, or `use_presidio: true` with appropriate entities.
+3. **OCR-derived text**. if the PDF has both text and image layers, some text may come from the image layer. Use `--force-ocr` to OCR all pages.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -63,5 +63,5 @@ redactron --version
 ## Build smoke test
 
 The `release.yml` workflow also runs a build-only job on every push to `main`
-(no publish). This catches packaging regressions early — if `uv build` fails,
+(no publish). This catches packaging regressions early. If `uv build` fails,
 the CI check fails before any tag is pushed.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,14 +8,14 @@
 | Accidental git commit | `vault.enc` pushed to repo | Opaque ciphertext; no plaintext PII |
 | Cloud sync (iCloud, Dropbox) | `vault.enc` synced to cloud | Ciphertext only; `redactron init` warns on cloud-sync paths |
 | Physical access to unlocked machine | Reads vault without user present | Touch ID required via LocalAuthentication before every vault access |
-| Live malware on user's machine | Reads keychain directly (bypassing redactron) | Soft enforcement only — see limitations below |
+| Live malware on user's machine | Reads keychain directly (bypassing redactron) | Soft enforcement only. See limitations below. |
 | Kernel-level compromise | Bypasses all user-space controls | Out of scope |
 
 ## Crypto choices
 
 ### AES-256-GCM
 
-- **Why GCM, not CBC:** GCM is authenticated encryption (AEAD). Any bit flip in the ciphertext raises `InvalidTag` before any plaintext is returned. CBC has no authentication tag — an attacker can flip bits and receive modified plaintext silently.
+- **Why GCM, not CBC:** GCM is authenticated encryption (AEAD). Any bit flip in the ciphertext raises `InvalidTag` before any plaintext is returned. CBC has no authentication tag; an attacker can flip bits and receive modified plaintext silently.
 - **Why not ChaCha20-Poly1305:** Deferred to v1.1 for cross-platform support. AES-GCM has hardware acceleration on all modern x86 and Apple Silicon.
 - **Key size:** 256 bits (`secrets.token_bytes(32)`). NIST-approved for top-secret classification.
 - **Nonce:** 96 bits (`os.urandom(12)`) generated fresh for every `save()` call. GCM nonce reuse with the same key is catastrophic; fresh random nonces make reuse statistically impossible.
@@ -33,7 +33,7 @@ redactron uses `LAContext.evaluatePolicy(LAPolicyDeviceOwnerAuthenticationWithBi
 
 - The Touch ID prompt fires; if cancelled or failed, redactron refuses to proceed.
 - The master key is stored in the login keychain (standard ACL, not `kSecAttrAccessControl`).
-- This works for unsigned Python processes — no Apple Developer account or code signing required.
+- This works for unsigned Python processes. No Apple Developer account or code signing required.
 - A determined attacker with shell access to your unlocked machine could read the keychain directly, bypassing redactron's Touch ID gate.
 
 **Why not `kSecAttrAccessControl` (hardware-backed ACL)?**
@@ -69,9 +69,9 @@ The JSON payload is decrypted in-memory only and never written to disk.
 
 | Platform | Status |
 |---|---|
-| macOS (darwin) | ✅ Supported in v1 — Touch ID via LocalAuthentication |
-| Linux | 🔜 Planned for v1.1 (libsecret/SecretService) |
-| Windows | 🔜 Planned for v1.1 (DPAPI/Credential Manager) |
+| macOS (darwin) | Supported in v1. Touch ID via LocalAuthentication. |
+| Linux | Planned for v1.1 (libsecret/SecretService) |
+| Windows | Planned for v1.1 (DPAPI/Credential Manager) |
 
 ## Reporting security issues
 


### PR DESCRIPTION
Replace emoji comparison table with prose. Fix stale WARNING/INFO log level references in PROFILE.md. Add v0.1.1 CHANGELOG entry. Tighten wordy phrases.

---
Credits: 6 | Time: 240s