### PR TITLE
feat(cli): profile template subcommand + init hint (BLD-FIX-29, BLD-FIX-30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ For professional use, the vault stores multiple client profiles encrypted with A
 pip install redactron
 redactron init
 redactron vault init
-redactron profile add --client me --from docs/examples/profile-template.yaml
+redactron profile template --output /tmp/me.yaml
+# edit /tmp/me.yaml with your details
+redactron profile add --client me --from /tmp/me.yaml
 redactron run document.pdf --client me
 ```
 
@@ -115,6 +117,7 @@ redactron verify <path>
 redactron init
 redactron vault init
 redactron profile add --client <id> [--name <name>] [--from <yaml>]
+redactron profile template [--output <path>] [--client <id>]
 redactron profile list
 redactron profile show <id> [--reveal]
 redactron profile edit <id>

--- a/docs/PROFILE.md
+++ b/docs/PROFILE.md
@@ -350,8 +350,8 @@ If `~/.redactron/profile.yaml` exists alongside `vault.enc`, redactron uses `pro
 The recommended way to add a new client profile:
 
 ```bash
-# 1. Copy the annotated template
-cp docs/examples/profile-template.yaml /tmp/alice.yaml
+# 1. Export the bundled template
+redactron profile template --output /tmp/alice.yaml
 
 # 2. Fill in values (open in your editor)
 $EDITOR /tmp/alice.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ source = "vcs"
 packages = ["src/redactron"]
 artifacts = ["docs/examples"]
 
+[tool.hatch.build.targets.wheel.shared-data]
+"src/redactron/data" = "redactron/data"
+
 [dependency-groups]
 dev = [
     "pytest==8.3.3",

--- a/src/redactron/cli.py
+++ b/src/redactron/cli.py
@@ -117,7 +117,7 @@ def init() -> None:
     else:
         typer.echo(
             "\nTo add your first client profile:\n"
-            "  1. Copy docs/examples/profile-template.yaml to /tmp/me.yaml\n"
+            "  1. redactron profile template --output /tmp/me.yaml\n"
             "  2. Fill in your PII values\n"
             "  3. redactron profile add --client me --from /tmp/me.yaml"
         )
@@ -830,6 +830,30 @@ def profile_list() -> None:
     typer.echo("-" * 70)
     for m in metas:
         typer.echo(f"{m.client_id:<20}  {m.display_name:<30}  {m.created_at[:10]}")
+
+
+@profile_app.command("template")
+def profile_template(
+    output: str = typer.Option("", "--output", "-o", help="Write template to path."),
+    client: str = typer.Option("", "--client", "-c", help="Pre-fill display_name."),
+) -> None:
+    """Print the bundled profile template. Save to a file, fill in values, then import."""
+    import importlib.resources as ir
+
+    text = (ir.files("redactron") / "data" / "profile-template.yaml").read_text()
+
+    if client:
+        text = text.replace('display_name: ""', f'display_name: "{client}"', 1)
+
+    if output:
+        out_path = Path(output)
+        out_path.write_text(text)
+        typer.echo(f"✅ Template written to {out_path}")
+        typer.echo(
+            f"   Fill in values, then: redactron profile add --client <id> --from {out_path}"
+        )
+    else:
+        typer.echo(text, nl=False)
 
 
 @profile_app.command("show")

--- a/src/redactron/data/profile-template.yaml
+++ b/src/redactron/data/profile-template.yaml
@@ -1,0 +1,47 @@
+# Redactron profile template — full annotated schema.
+#
+# Copy this file, fill in values, then import:
+#   redactron profile add --client <id> --from /path/to/copy.yaml
+#
+# The source file is secure-wiped (3-pass overwrite + unlink)
+# after successful import.
+#
+# All fields are optional except subject.display_name.
+
+version: 1
+name: ""  # optional: human-readable profile name (not the client ID)
+
+subject:
+  display_name: ""        # required: primary subject name (e.g. "Jane Smith")
+  aliases: []             # variant spellings, "Last, First", nicknames
+                          # e.g. ["Jane", "J. Smith", "Smith, Jane"]
+  addresses: []           # full mailing addresses; multi-line OK
+                          # e.g. ["123 Main Street, Springfield, IL 62701"]
+  phones: []              # any format; matching normalizes digits
+                          # e.g. ["+1-555-867-5309", "555.867.5309"]
+  emails: []              # exact match (case-insensitive)
+                          # e.g. ["jane@example.com"]
+  ssns: []                # XXX-XX-XXXX format
+                          # e.g. ["123-45-6789"]
+  account_numbers: []     # list of {value: "...", preserve_last: N}
+                          # preserve_last: keep last N digits visible (default 4)
+                          # e.g. [{value: "ACC-9900112233", preserve_last: 4}]
+  custom_patterns: []     # named regex patterns
+                          # e.g. [{name: "employee_id", regex: "EMP-\\d{6}"}]
+
+detection:
+  use_presidio: false     # enable Microsoft Presidio NLP for auto-detection
+                          # of PHONE_NUMBER, EMAIL_ADDRESS, etc.
+  presidio_entities: []   # whitelist when use_presidio: true
+                          # e.g. ["PHONE_NUMBER", "EMAIL_ADDRESS", "US_SSN"]
+  fuzzy_match: true       # fuzzy-match names and aliases (recommended)
+  match_threshold: 0.85   # 0.0–1.0; lower = more permissive (more false positives)
+                          # raise to 0.99 to distinguish house numbers
+  full_token_min_length: 2  # ignore tokens shorter than this (avoids "I", "a")
+  ocr_fallback: true      # auto-OCR image-only pages via pytesseract
+                          # requires Tesseract installed; set false to disable
+  column_aware: true      # restrict address bridging to same column
+                          # (prevents cross-column false positives in two-column PDFs)
+  scan_figures: false     # detect text inside figure/drawing regions
+                          # false = skip figures (recommended for most docs)
+  address_line_bridge_window: 3  # max lines to bridge for multi-line addresses


### PR DESCRIPTION
Adds `redactron profile template` command. Ships template as package data. Updates init hint and README quickstart. 335 tests pass.

Closes BLD-FIX-29, BLD-FIX-30

---
Credits: 8 | Time: 300s