### PR TITLE
fix(cli): client-not-found concise hint (BLD-55)

### DIFF
--- a/src/redactron/cli.py
+++ b/src/redactron/cli.py
@@ -692,10 +692,11 @@ def _load_profile_for_client(client_id: str) -> Profile:
     store = _get_vault_store()
     profile_dict = store.get_profile(client_id)
     if profile_dict is None:
-        metas = store.list_profiles()
-        available = ", ".join(m.client_id for m in metas) or "(none)"
         typer.echo(
-            f"Error: client '{client_id}' not found in vault. Available: {available}",
+            f"Error: client '{client_id}' not found in vault.\n"
+            "Try:\n"
+            "  redactron profile list\n"
+            "  redactron --help",
             err=True,
         )
         raise typer.Exit(1)

--- a/tests/test_client_flag.py
+++ b/tests/test_client_flag.py
@@ -91,7 +91,7 @@ def test_run_client_missing_shows_available(tmp_path: Path) -> None:
         )
     assert result.exit_code == 1
     assert "ghost" in result.output
-    assert "alice" in result.output
+    assert "not found" in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replaces client list flood with concise suggestions. 336 tests pass.

Closes BLD-55

---
Credits: 4 | Time: 120s