### PR TITLE
release: v0.1.2 — template fixes + gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ build/
 .ruff_cache/
 .pytest_cache/
 *.db
-!.redactron/.gitkeep
 htmlcov/
 .coverage
+.kiro/
+.redactron/
+scripts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning: [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-05-04
+
+### Fixed
+
+- Profile template `account_numbers` field now uses block sequence format instead of `[]`, so users can uncomment the example directly without restructuring the YAML.
+- README profile example uses a realistic account number (`0021305789Q834`) matching the template example.
+
+### Changed
+
+- Removed `.kiro/`, `.redactron/`, and `scripts/` from repository history. These contained internal tooling, prompts, and credit-tracking scripts that are not part of the build or usable product.
+
 ## [0.1.1] — 2026-05-04
 
 ### Fixed
@@ -89,5 +100,6 @@ First public release. Covers milestones M1 through M4 and M3.5.
 - cryptography 43.0.3
 - keyring 25.5.0
 
+[0.1.2]: https://github.com/tjndr/redactron/releases/tag/v0.1.2
 [0.1.1]: https://github.com/tjndr/redactron/releases/tag/v0.1.1
 [0.1.0]: https://github.com/tjndr/redactron/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install redactron
 redactron init
 redactron vault init
 
-# Get the profile template, fill in your details, import it
+# Get the profile template — use this for every new profile
 redactron profile template --output /tmp/me.yaml
 # edit /tmp/me.yaml with your name, addresses, account numbers, etc.
 redactron profile add --client me --from /tmp/me.yaml
@@ -47,11 +47,11 @@ redactron profile add --client me --from /tmp/me.yaml
 # Redact a single file
 redactron run document.pdf --client me
 
-# Redact an entire folder — outputs go to ./redacted/
+# Redact multiple files in a folder — outputs go to ./documents/redacted/
 redactron run ./documents/ --client me
 ```
 
-`document_redacted.pdf` lands in the same directory. For a folder, redacted files go to `documents/redacted/`, with a consolidated summary report in `documents/redacted-reports/`.
+`document_redacted.pdf` lands in the same directory as the input. For a folder, all redacted files go to `documents/redacted/` and a consolidated summary report is written to `documents/redacted-reports/`.
 
 ## Features
 
@@ -77,7 +77,7 @@ subject:
   phones: ["+1-555-867-5309"]
   emails: ["jane@example.com"]
   account_numbers:
-    - value: "ACC-9900112233"
+    - value: "0021305789Q834"
       preserve_last: 4
 detection:
   fuzzy_match: true

--- a/docs/examples/profile-template.yaml
+++ b/docs/examples/profile-template.yaml
@@ -23,12 +23,9 @@ subject:
                           # e.g. ["jane@example.com"]
   ssns: []                # XXX-XX-XXXX format
                           # e.g. ["123-45-6789"]
-  account_numbers: []     # list of account numbers to redact
-                          # preserve_last: keep last N digits visible (default 4)
-                          # Example (uncomment and fill in):
-                          # account_numbers:
-                          #   - value: "0021305789Q834"
-                          #     preserve_last: 4
+  account_numbers:          # list of account numbers to redact; preserve_last keeps last N digits visible
+    # - value: "0021305789Q834"
+    #   preserve_last: 4
   custom_patterns: []     # named regex patterns
                           # Example:
                           # custom_patterns:

--- a/src/redactron/data/profile-template.yaml
+++ b/src/redactron/data/profile-template.yaml
@@ -23,12 +23,9 @@ subject:
                           # e.g. ["jane@example.com"]
   ssns: []                # XXX-XX-XXXX format
                           # e.g. ["123-45-6789"]
-  account_numbers: []     # list of account numbers to redact
-                          # preserve_last: keep last N digits visible (default 4)
-                          # Example (uncomment and fill in):
-                          # account_numbers:
-                          #   - value: "0021305789Q834"
-                          #     preserve_last: 4
+  account_numbers:          # list of account numbers to redact; preserve_last keeps last N digits visible
+    # - value: "0021305789Q834"
+    #   preserve_last: 4
   custom_patterns: []     # named regex patterns
                           # Example:
                           # custom_patterns:


### PR DESCRIPTION
## v0.1.2

### Fixed
- Profile template `account_numbers` field now uses block sequence format instead of `[]`. Users can uncomment the example directly without restructuring YAML.
- README profile example uses `0021305789Q834` matching the template.

### Changed
- CHANGELOG: 0.1.2 entry added.
- `.gitignore`: Added `.kiro/`, `.redactron/`, `scripts/` so they are never accidentally re-tracked.

### History cleanup (separate step)
`.kiro/`, `.redactron/`, and `scripts/` have been removed from all commit history locally via `git filter-repo`. The rewritten history is on the `release/v0.1.2-clean` branch. To apply it, an admin needs to temporarily disable the "Main Protection" ruleset and force-push:
```
git checkout main  # the rewritten local main
git push origin main --force
```
Tag `v0.1.2` is already pushed.