### PR TITLE
build: exclude .kiro/, .redactron/, scripts/ from sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ redactron = "redactron.cli:app"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+  ".kiro",
+  ".redactron",
+  "scripts",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/redactron"]
 artifacts = ["docs/examples"]


### PR DESCRIPTION
Adds `[tool.hatch.build.targets.sdist] exclude` to prevent `.kiro/`, `.redactron/`, and `scripts/` from being bundled in future source distributions on PyPI.

The existing 0.1.0 and 0.1.1 releases on PyPI contain these files. Those need to be deleted manually at pypi.org/manage/project/redactron/ (PyPI does not support deletion via API).